### PR TITLE
GPOS STIG v3r2 Update

### DIFF
--- a/gpos/xml/scap/ssg/content/ssg-chainguard-gpos-ds.xml
+++ b/gpos/xml/scap/ssg/content/ssg-chainguard-gpos-ds.xml
@@ -4,13 +4,13 @@
     xmlns:ds="http://scap.nist.gov/schema/scap/source/1.2"
     xmlns:xlink="http://www.w3.org/1999/xlink"
     xmlns:cat="urn:oasis:names:tc:entity:xmlns:xml:catalog"
-    id="scap_org.open-scap_collection_from_xccdf_all-resolved-xccdf-dummyoval.xml"
+    id="scap_org.open-scap_collection_from_xccdf_all-resolved-xccdf-v3r2.xml"
     schematron-version="1.2">
-    <ds:data-stream id="scap_org.open-scap_datastream_from_xccdf_all-resolved-xccdf-dummyoval.xml"
+    <ds:data-stream id="scap_org.open-scap_datastream_from_xccdf_all-resolved-xccdf-v3r2.xml"
         scap-version="1.2" use-case="OTHER">
         <ds:checklists>
-            <ds:component-ref id="scap_org.open-scap_cref_all-resolved-xccdf-dummyoval.xml"
-                xlink:href="#scap_org.open-scap_comp_all-resolved-xccdf-dummyoval.xml">
+            <ds:component-ref id="scap_org.open-scap_cref_all-resolved-xccdf-v3r2.xml"
+                xlink:href="#scap_org.open-scap_comp_all-resolved-xccdf-v3r2.xml">
                 <cat:catalog>
                     <cat:uri name="PackageSignatureTest.xml"
                         uri="#scap_org.open-scap_cref_PackageSignatureTest" />
@@ -53,15 +53,15 @@
             <ds:component-ref id="scap_org.open-scap_cref_AslrCheck"
                 xlink:href="#scap_org_ecomp_.aslr" />
             <ds:component-ref id="scap_org.open-scap_cref_CertificateAuditTest"
-                xlink:href="#scap_org_ecomp_.certificateaudit" />
+                xlink:href="#scap_org_ecomp_.certaudit" />
         </ds:checks>
     </ds:data-stream>
-    <ds:component id="scap_org.open-scap_comp_all-resolved-xccdf-dummyoval.xml"
+    <ds:component id="scap_org.open-scap_comp_all-resolved-xccdf-v3r2.xml"
         timestamp="2016-02-23T14:39:05">
         <ns0:Benchmark xmlns:html="http://www.w3.org/1999/xhtml"
             id="xccdf_org.open-scap.sce-community-content_benchmark_all" resolved="1" xml:lang="en">
             <ns0:status date="2016-02-23">draft</ns0:status>
-            <ns0:title xml:lang="en">Datastream XCCDF Checklist Beta</ns0:title>
+            <ns0:title xml:lang="en">Datastream XCCDF Checklist Beta GPOS v3r2</ns0:title>
             <ns0:description>This XCCDF document provides a basic security check for a Linux system.</ns0:description>
             <ns0:notice id="disclaimer" xml:lang="en" />
             <ns0:front-matter xml:lang="en" />
@@ -6394,22 +6394,25 @@
                             To manually verify, Ensure the ca-certificates package has been modified
                             using apk audit</html:pre>
                     </ns0:description>
-                    <ns0:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-                        <ns0:check-content-ref href="CertificateAuditTest.sh" />
+                    <ns0:check system="http://open-scap.org/page/SCE">
+                        <ns0:check-import import-name="stdout" />
+                        <ns0:check-content-ref href="./CertificateAuditTest.sh" />
                     </ns0:check>
                 </ns0:Rule>
             </ns0:Group>
         </ns0:Benchmark>
     </ds:component>
     <ds:extended-component xmlns:oscap-sce-xccdf-stream="http://open-scap.org/page/SCE_xccdf_stream"
-        id="scap_org_ecomp_.certificateaudit" timestamp="2016-02-23T14:36:08">
+        id="scap_org_ecomp_.certaudit" timestamp="2016-02-23T14:36:08">
         <oscap-sce-xccdf-stream:script>#!/bin/sh
-            modified=$(apk audit --packages | grep '^ca-certificates')
+            EXPECTED_HASH="756cdfe4c3affc2e460278cc65ab01f67c3f4fc05d43fc683d7ebbdeb644e5f4"
+            ACTUAL_HASH=$(sha256sum /etc/ssl/certs/ca-certificates.crt | awk '{print $1}')
 
-            if [ -z "$modified" ]; then
+            if [ "$ACTUAL_HASH" = "$EXPECTED_HASH" ]; then
+            echo "PASS: Hash matches approved CA bundle"
             return $XCCDF_RESULT_PASS
             else
-            echo "ca-certificates package has been modified"
+            echo "FAIL: Hash does not match approved CA bundle: $ACTUAL_HASH"
             return $XCCDF_RESULT_FAIL
             fi
         </oscap-sce-xccdf-stream:script>
@@ -6425,7 +6428,7 @@
             echo "ASLR not configured correctly"
             return $XCCDF_RESULT_FAIL
             fi
-</oscap-sce-xccdf-stream:script>
+        </oscap-sce-xccdf-stream:script>
     </ds:extended-component>
     <ds:extended-component id="scap_org_ecomp_.openssl" timestamp="2024-05-29T12:00:00">
         <oval_definitions xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5"

--- a/gpos/xml/scap/ssg/content/ssg-chainguard-gpos-ds.xml
+++ b/gpos/xml/scap/ssg/content/ssg-chainguard-gpos-ds.xml
@@ -28,6 +28,8 @@
                         uri="#scap_org.open-scap_cref_DetectOpenSslTest" />
                     <cat:uri name="AslrCheck.sh"
                         uri="#scap_org.open-scap_cref_AslrCheck" />
+                    <cat:uri name="CertificateAuditTest.sh"
+                        uri="#scap_org.open-scap_cref_CertificateAuditTest" />
                 </cat:catalog>
             </ds:component-ref>
         </ds:checklists>
@@ -50,6 +52,8 @@
                 xlink:href="#scap_org_ecomp_.openssl" />
             <ds:component-ref id="scap_org.open-scap_cref_AslrCheck"
                 xlink:href="#scap_org_ecomp_.aslr" />
+            <ds:component-ref id="scap_org.open-scap_cref_CertificateAuditTest"
+                xlink:href="#scap_org_ecomp_.certificateaudit" />
         </ds:checks>
     </ds:data-stream>
     <ds:component id="scap_org.open-scap_comp_all-resolved-xccdf-dummyoval.xml"
@@ -155,8 +159,366 @@
                 <ns0:select idref="xccdf_._rule_V_203640" selected="true" />
                 <ns0:select idref="xccdf_._rule_V_203641" selected="true" />
                 <ns0:select idref="xccdf_._rule_V_203716" selected="true" />
+                <ns0:select idref="xccdf_._rule_V_263650" selected="true" />
+                <ns0:select idref="xccdf_._rule_V_263652" selected="true" />
+                <ns0:select idref="xccdf_._rule_V_263659" selected="true" />
+
+
             </ns0:Profile>
             <ns0:Group id="xccdf_._group_not_applicable_tests">
+                <ns0:Rule id="xccdf_._rule_V_263651" selected="true" severity="medium">
+                    <ns0:title xml:lang="en">The operating system must prohibit the use or
+                        connection of
+                        unauthorized hardware
+                        components.</ns0:title>
+                    <ns0:description xml:lang="en">Hardware components provide the foundation for
+                        organizational systems and the platform for the execution of authorized
+                        software
+                        programs. Managing the inventory of hardware components and controlling
+                        which
+                        hardware components are permitted to be installed or connected to
+                        organizational
+                        systems is essential to provide adequate
+                        security.</ns0:description>
+                    <ns0:rationale>Linux containers do not automatically inherit access to
+                        underlying hardware such as USB and
+                        WiFi adapters on the hosts where they operate. If these connections exist,
+                        they must be specifically configured when deploying the image on a host. A
+                        host configured to meet STIG requirements will disable unused USB
+                        connections and implement properly configured WiFi interfaces (if necessary
+                        for the operation of the service).
+
+                        For more information on inherited controls for containers see the DISA
+                        Container Hardening Process Guide.</ns0:rationale>
+                    <ns0:platform idref="cpe:/o:notapplicable" />
+                </ns0:Rule>
+                <ns0:Rule id="xccdf_._rule_V_263653" selected="true" severity="medium">
+                    <ns0:title xml:lang="en">The operating system must, for password-based
+                        authentication, verify
+                        when users
+                        create or update passwords the passwords are not found on the list of
+                        commonly-used,
+                        expected, or compromised passwords in IA-5 (1) (a).</ns0:title>
+                    <ns0:description xml:lang="en">Password-based authentication applies to
+                        passwords
+                        regardless of whether they are used in single-factor or multifactor
+                        authentication.
+                        Long passwords or passphrases are preferable over shorter passwords.
+                        Enforced
+                        composition rules provide marginal security benefits while decreasing
+                        usability.
+                        However, organizations may choose to establish certain rules for password
+                        generation
+                        (e.g., minimum character length for long passwords) under certain
+                        circumstances and
+                        can enforce this requirement in IA-5(1)(h). Account recovery can occur, for
+                        example,
+                        in situations when a password is forgotten. Cryptographically protected
+                        passwords
+                        include salted one-way cryptographic hashes of passwords. The list of
+                        commonly used,
+                        compromised, or expected passwords includes passwords obtained from previous
+                        breach
+                        corpuses, dictionary words, and repetitive or sequential characters. The
+                        list
+                        includes context-specific words, such as the name of the service, username,
+                        and
+                        derivatives
+                        thereof.</ns0:description>
+                    <ns0:rationale>The container image is built with no local user accounts other
+                        than a locked
+                        root. All interactive or programmatic access to the workload is handled by
+                        the
+                        container-orchestration platform, which enforces its own credential hygiene
+                        and MFA
+                        controls. The OS inside the container never receives, stores, or validates
+                        passwords and no
+                        password database exists against which to apply bad-password screening,
+                        forced post-recovery
+                        changes, passphrase-length rules, or password-generation aids.
+
+                        For more information on inherited controls for containers see the DISA
+                        Container Hardening Process Guide.</ns0:rationale>
+                    <ns0:platform idref="cpe:/o:notapplicable" />
+                </ns0:Rule>
+                <ns0:Rule id="xccdf_._rule_V_263654" selected="true" severity="medium">
+                    <ns0:title xml:lang="en">The operating system must for password-based
+                        authentication, require
+                        immediate
+                        selection of a new password upon account recovery.</ns0:title>
+                    <ns0:description xml:lang="en">Password-based authentication applies to
+                        passwords
+                        regardless of whether they are used in single-factor or multifactor
+                        authentication.
+                        Long passwords or passphrases are preferable over shorter passwords.
+                        Enforced
+                        composition rules provide marginal security benefits while decreasing
+                        usability.
+                        However, organizations may choose to establish certain rules for
+                        password generation
+                        (e.g., minimum character length for long passwords) under certain
+                        circumstances and
+                        can enforce this requirement in IA-5(1)(h). Account recovery can occur,
+                        for example,
+                        in situations when a password is forgotten. Cryptographically protected
+                        passwords
+                        include salted one-way cryptographic hashes of passwords. The list of
+                        commonly used,
+                        compromised, or expected passwords includes passwords obtained from
+                        previous breach
+                        corpuses, dictionary words, and repetitive or sequential characters. The
+                        list
+                        includes context-specific words, such as the name of the service,
+                        username, and
+                        derivatives
+                        thereof.</ns0:description>
+                    <ns0:rationale>The container image is built with no local user accounts
+                        other than a locked
+                        root. All interactive or programmatic access to the workload is handled
+                        by the
+                        container-orchestration platform, which enforces its own credential
+                        hygiene and MFA
+                        controls. The OS inside the container never receives, stores, or
+                        validates passwords and no
+                        password database exists against which to apply bad-password screening,
+                        forced post-recovery
+                        changes, passphrase-length rules, or password-generation aids.
+
+                        For more information on inherited controls for containers see the DISA
+                        Container Hardening Process Guide.</ns0:rationale>
+                    <ns0:platform idref="cpe:/o:notapplicable" />
+                </ns0:Rule>
+                <ns0:Rule id="xccdf_._rule_V_263655" selected="true" severity="medium">
+                    <ns0:title xml:lang="en">The operating system must for password-based
+                        authentication, allow user
+                        selection
+                        of long passwords and passphrases, including spaces and all printable
+                        characters.</ns0:title>
+                    <ns0:description xml:lang="en">Password-based authentication applies to
+                        passwords
+                        regardless of whether they are used in single-factor or multifactor
+                        authentication.
+                        Long passwords or passphrases are preferable over shorter passwords.
+                        Enforced
+                        composition rules provide marginal security benefits while decreasing
+                        usability.
+                        However, organizations may choose to establish certain rules for password
+                        generation
+                        (e.g., minimum character length for long passwords) under certain
+                        circumstances and
+                        can enforce this requirement in IA-5(1)(h). Account recovery can occur, for
+                        example,
+                        in situations when a password is forgotten. Cryptographically protected
+                        passwords
+                        include salted one-way cryptographic hashes of passwords. The list of
+                        commonly used,
+                        compromised, or expected passwords includes passwords obtained from previous
+                        breach
+                        corpuses, dictionary words, and repetitive or sequential characters. The
+                        list
+                        includes context-specific words, such as the name of the service, username,
+                        and
+                        derivatives
+                        thereof.</ns0:description>
+                    <ns0:rationale>The container image is built with no local user accounts other
+                        than a locked
+                        root. All interactive or programmatic access to the workload is handled by
+                        the
+                        container-orchestration platform, which enforces its own credential hygiene
+                        and MFA
+                        controls. The OS inside the container never receives, stores, or validates
+                        passwords and no
+                        password database exists against which to apply bad-password screening,
+                        forced post-recovery
+                        changes, passphrase-length rules, or password-generation aids.
+
+                        For more information on inherited controls for containers see the DISA
+                        Container Hardening Process Guide.</ns0:rationale>
+                    <ns0:platform idref="cpe:/o:notapplicable" />
+                </ns0:Rule>
+                <ns0:Rule id="xccdf_._rule_V_263656" selected="true" severity="medium">
+                    <ns0:title xml:lang="en">The operating system must, for password-based
+                        authentication, employ
+                        automated
+                        tools to assist the user in selecting strong password authenticators.</ns0:title>
+                    <ns0:description xml:lang="en">Password-based authentication applies to
+                        passwords
+                        regardless of whether they are used in single-factor or multifactor
+                        authentication.
+                        Long passwords or passphrases are preferable over shorter passwords.
+                        Enforced
+                        composition rules provide marginal security benefits while decreasing
+                        usability.
+                        However, organizations may choose to establish certain rules for password
+                        generation
+                        (e.g., minimum character length for long passwords) under certain
+                        circumstances and
+                        can enforce this requirement in IA-5(1)(h). Account recovery can occur, for
+                        example,
+                        in situations when a password is forgotten. Cryptographically protected
+                        passwords
+                        include salted one-way cryptographic hashes of passwords. The list of
+                        commonly used,
+                        compromised, or expected passwords includes passwords obtained from previous
+                        breach
+                        corpuses, dictionary words, and repetitive or sequential characters. The
+                        list
+                        includes context-specific words, such as the name of the service, username,
+                        and
+                        derivatives
+                        thereof.</ns0:description>
+                    <ns0:rationale>The container image is built with no local user accounts other
+                        than a locked
+                        root. All interactive or programmatic access to the workload is handled by
+                        the
+                        container-orchestration platform, which enforces its own credential hygiene
+                        and MFA
+                        controls. The OS inside the container never receives, stores, or validates
+                        passwords and no
+                        password database exists against which to apply bad-password screening,
+                        forced post-recovery
+                        changes, passphrase-length rules, or password-generation aids.
+
+                        For more information on inherited controls for containers see the DISA
+                        Container Hardening Process Guide.</ns0:rationale>
+                    <ns0:platform idref="cpe:/o:notapplicable" />
+                </ns0:Rule>
+                <ns0:Rule id="xccdf_._rule_V_263657" selected="true" severity="medium">
+                    <ns0:title xml:lang="en">The operating system must accept only external
+                        credentials that are
+                        NIST-compliant</ns0:title>
+                    <ns0:description xml:lang="en">Acceptance of only NIST-compliant external
+                        authenticators applies to organizational systems that are accessible to the
+                        public
+                        (e.g., public-facing websites). External authenticators are issued by
+                        nonfederal
+                        government entities and are compliant with [SP 800-63B]. Approved external
+                        authenticators meet or exceed the minimum federal government-wide technical,
+                        security, privacy, and organizational maturity requirements. Meeting or
+                        exceeding
+                        federal requirements allows federal government relying parties to trust
+                        external
+                        authenticators in connection with an authentication transaction at a
+                        specified
+                        authenticator assurance
+                        level.</ns0:description>
+                    <ns0:rationale>Linux containers rely on the host operating system to manage and
+                        enforce
+                        authentication mechanisms, including the validation of external credentials.
+                        Because
+                        containers delegate user authentication and identity management to the host
+                        environment, it is the host operating system that is ultimately responsible
+                        for ensuring
+                        that only NIST-compliant external authenticators are accepted.
+
+                        For more information on inherited controls for containers, see the DISA
+                        Container Hardening
+                        Process Guide.</ns0:rationale>
+                    <ns0:platform idref="cpe:/o:notapplicable" />
+                </ns0:Rule>
+                <ns0:Rule id="xccdf_._rule_V_263658" selected="true" severity="medium">
+                    <ns0:title xml:lang="en">The operating system must monitor the use of
+                        maintenance tools that
+                        execute with
+                        increased privilege</ns0:title>
+                    <ns0:description xml:lang="en">Maintenance tools that execute with increased
+                        system
+                        privilege can result in unauthorized access to organizational information
+                        and assets
+                        that would otherwise be
+                        inaccessible.</ns0:description>
+                    <ns0:rationale>Auditing capabilities for Linux containers are implemented by the
+                        underlying host's audit configuration. In Linux, the auditing program auditd
+                        leverages multiple functions in the running kernel through the Linux
+                        Auditing System to capture runtime information such as process start / stop,
+                        opening sockets, and accessing files.
+
+                        Linux containers utilize the host's kernel, making it impossible to install
+                        and operate a separate auditing package inside the container itself.
+                        Instead, auditing information must be configured and collected through the
+                        audit configuration of the host.
+
+                        Once configured, logs of container actions are written to the host's audit
+                        log files and are readable only by the host superuser account. These logs
+                        must be collected from the host for incident response and reporting. Storage
+                        capacity limits, audit process monitoring, remote upload of logs and
+                        associated alerts are the responsibility of the host where the containers
+                        are running.
+
+                        For more information on inherited controls for containers see the DISA
+                        Container Hardening Process Guide.</ns0:rationale>
+                    <ns0:platform idref="cpe:/o:notapplicable" />
+                </ns0:Rule>
+                <ns0:Rule id="xccdf_._rule_V_263660" selected="true" severity="medium">
+                    <ns0:title xml:lang="en">The operating system must provide protected storage for
+                        cryptographic
+                        keys with
+                        organization-defined safeguards and/or hardware protected key store.</ns0:title>
+                    <ns0:description xml:lang="en">A Trusted Platform Module (TPM) is an example of
+                        a
+                        hardware-protected data store that can be used to protect cryptographic
+                        keys.</ns0:description>
+                    <ns0:rationale>Linux containers utilize the host filesystem for storage of their
+                        files and
+                        configuration. Protecting data at rest inside containers from unauthorized
+                        access or
+                        modification must be configured at the host operating system such as
+                        encrypted virtual
+                        filesystems. The host filesystem is also responsible for the size,
+                        utilization, and capacity
+                        of the physical disks that are used by containers running on that host.
+
+                        For more information on inherited controls for containers see the DISA
+                        Container Hardening Process Guide.</ns0:rationale>
+                    <ns0:platform idref="cpe:/o:notapplicable" />
+                </ns0:Rule>
+                <ns0:Rule id="xccdf_._rule_V_263661" selected="true" severity="medium">
+                    <ns0:title xml:lang="en">The operating system must synchronize system clocks
+                        within and between
+                        systems or
+                        system components.</ns0:title>
+                    <ns0:description xml:lang="en">Time synchronization of system clocks is
+                        essential
+                        for the correct execution of many system services, including identification
+                        and
+                        authentication processes that involve certificates and time-of-day
+                        restrictions as
+                        part of access control. Denial of service or failure to deny expired
+                        credentials may
+                        result without properly synchronized clocks within and between systems and
+                        system
+                        components. Time is commonly expressed in Coordinated Universal Time (UTC),
+                        a modern
+                        continuation of Greenwich Mean Time (GMT), or local time with an offset from
+                        UTC.
+                        The granularity of time measurements refers to the degree of synchronization
+                        between
+                        system clocks and reference clocks, such as clocks synchronizing within
+                        hundreds of
+                        milliseconds or tens of milliseconds. Organizations may define different
+                        time
+                        granularities for system components. Time service can be critical to other
+                        security
+                        capabilities—such as access control and identification and
+                        authentication—depending
+                        on the nature of the mechanisms used to support the
+                        capabilities.</ns0:description>
+                    <ns0:rationale>Linux containers inherit the system time from the underlying host
+                        - a separate
+                        time service is not operated within the container. The host owner is
+                        responsible for
+                        configuring the host's time service to generate the timestamp used by its
+                        auditing system,
+                        perform periodic synchronization, and ensure that only authorized time
+                        servers are used as
+                        the authoritative source. Time synchronization of the host clock is
+                        automatically reflected
+                        in the time used by the container.
+
+                        For more information on inherited controls for containers see the DISA
+                        Container Hardening Process Guide.</ns0:rationale>
+                    <ns0:platform idref="cpe:/o:notapplicable" />
+                </ns0:Rule>
                 <ns0:Rule id="xccdf_._rule_V_203682" selected="true" severity="high">
                     <ns0:title xml:lang="en">The operating system must use cryptographic mechanisms
                         to protect the integrity of audit tools.</ns0:title>
@@ -3642,6 +4004,41 @@
                 </ns0:Rule>
             </ns0:Group>
             <ns0:Group id="xccdf_._group_No_Remote_Access">
+                <ns0:Rule id="xccdf_._rule_V_263652" selected="true" severity="medium">
+                    <ns0:title xml:lang="en">The operating system must implement multifactor
+                        authentication for
+                        local,
+                        network, and/or remote access to privileged accounts and/or nonprivileged
+                        accounts
+                        such that the device meets organization-defined strength of mechanism
+                        requirements.</ns0:title>
+                    <ns0:description xml:lang="en">The purpose of requiring a device separate from
+                        the
+                        system to which the user is attempting to gain access for one of the factors
+                        during
+                        multifactor authentication is to reduce the likelihood of compromising
+                        authenticators or credentials stored on the system. Adversaries may be able
+                        to
+                        compromise such authenticators or credentials and subsequently impersonate
+                        authorized users. Implementing one of the factors on a separate device
+                        (e.g., a
+                        hardware token), provides a greater strength of mechanism and an increased
+                        level of
+                        assurance in the authentication
+                        process.</ns0:description>
+                    <ns0:description>
+                        <html:pre>Script Verification:
+                            To manually verify, Ensure none of the following remote access packages
+                            exist in the folder /lib/apk/db/ Packages: openssh, openssh-server,
+                            openssh-client, openssh-sftp-server, dropbear, tigervnc,
+                            tigervnc-server, tigervnc-viewer, xrdp, xorgxrdp, vsftpd, proftpd,
+                            webmin, cockpit, cockpit-ws, cockpit-bridge, nfs-utils, samba,
+                            samba-server, samba-client, samba-common, rsh, telnet</html:pre>
+                    </ns0:description>
+                    <ns0:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+                        <ns0:check-content-ref href="RemoteAccessServicesTest.xml" />
+                    </ns0:check>
+                </ns0:Rule>
                 <ns0:Rule id="xccdf_._rule_V_203736" selected="true" severity="high">
                     <ns0:title xml:lang="en">The operating system must implement cryptographic
                         mechanisms to protect the integrity of nonlocal maintenance and diagnostic
@@ -4025,26 +4422,35 @@
                         a device
                         separate from the system gaining access.</ns0:title>
                     <ns0:description xml:lang="en">Using an authentication device, such as a common
-                        access card (CAC) or token that is separate from the information system, ensures
-                        that even if the information system is compromised, that compromise will not affect
+                        access card (CAC) or token that is separate from the information system,
+                        ensures
+                        that even if the information system is compromised, that compromise will not
+                        affect
                         credentials stored on the authentication device.
-        
-                        Multifactor solutions that require devices separate from information systems gaining
+
+                        Multifactor solutions that require devices separate from information systems
+                        gaining
                         access include, for example, hardware tokens providing time-based or
-                        challenge-response authenticators and smart cards such as the U.S. Government
+                        challenge-response authenticators and smart cards such as the U.S.
+                        Government
                         Personal Identity Verification (PIV) card and the DOD CAC.
-        
-                        A privileged account is defined as an information system account with authorizations
+
+                        A privileged account is defined as an information system account with
+                        authorizations
                         of a privileged user.
-        
-                        Remote access is access to DOD nonpublic information systems by an authorized user
+
+                        Remote access is access to DOD nonpublic information systems by an
+                        authorized user
                         (or an information system) communicating through an external,
-                        nonorganization-controlled network. Remote access methods include, for example,
+                        nonorganization-controlled network. Remote access methods include, for
+                        example,
                         dial-up, broadband, and wireless.
-        
-                        This requirement only applies to components where this is specific to the function
+
+                        This requirement only applies to components where this is specific to the
+                        function
                         of the device or has the concept of an organizational user (e.g., VPN, proxy
-                        capability). This does not apply to authentication for the purpose of configuring
+                        capability). This does not apply to authentication for the purpose of
+                        configuring
                         the device itself
                         (management).</ns0:description>
                     <ns0:description>
@@ -5372,6 +5778,26 @@
                 </ns0:Rule>
             </ns0:Group>
             <ns0:Group id="xccdf_._group_No_Users">
+                <ns0:Rule id="xccdf_._rule_V_263650" selected="true" severity="medium">
+                    <ns0:title xml:lang="en">The operating system must disable accounts when the
+                        accounts are no
+                        longer
+                        associated to a user.</ns0:title>
+                    <ns0:description xml:lang="en">Disabling expired, inactive, or otherwise
+                        anomalous
+                        accounts supports the concepts of least privilege and least functionality
+                        which
+                        reduce the attack surface of the
+                        system.</ns0:description>
+                    <ns0:description>
+                        <html:pre>Script Verification:
+                            To manually verify, run command 'cat /etc/shadow and verify that no
+                            additional users exist</html:pre>
+                    </ns0:description>
+                    <ns0:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+                        <ns0:check-content-ref href="NoUsersCheck.xml" />
+                    </ns0:check>
+                </ns0:Rule>
                 <ns0:Rule id="xccdf_._rule_V_203695" selected="true" severity="high">
                     <ns0:title xml:lang="en">The operating system must prevent nonprivileged users
                         from executing privileged functions to include disabling, circumventing, or
@@ -5944,8 +6370,50 @@
                     </ns0:check>
                 </ns0:Rule>
             </ns0:Group>
+            <ns0:Group id="xccdf_._group_Certificate_Audits">
+                <ns0:Rule id="xccdf_._rule_V_263659" selected="true" severity="medium">
+                    <ns0:title xml:lang="en">The operating system must include only approved trust
+                        anchors in trust
+                        stores or
+                        certificate stores managed by the organization.</ns0:title>
+                    <ns0:description xml:lang="en">Public key infrastructure (PKI) certificates are
+                        certificates with visibility external to organizational systems and
+                        certificates
+                        related to the internal operations of systems, such as application-specific
+                        time
+                        services. In cryptographic systems with a hierarchical structure, a trust
+                        anchor is
+                        an authoritative source (i.e., a certificate authority) for which trust is
+                        assumed
+                        and not derived. A root certificate for a PKI system is an example of a
+                        trust
+                        anchor. A trust store or certificate store maintains a list of trusted root
+                        certificates.</ns0:description>
+                    <ns0:description>
+                        <html:pre>Script Verification:
+                            To manually verify, Ensure the ca-certificates package has been modified
+                            using apk audit</html:pre>
+                    </ns0:description>
+                    <ns0:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+                        <ns0:check-content-ref href="CertificateAuditTest.sh" />
+                    </ns0:check>
+                </ns0:Rule>
+            </ns0:Group>
         </ns0:Benchmark>
     </ds:component>
+    <ds:extended-component xmlns:oscap-sce-xccdf-stream="http://open-scap.org/page/SCE_xccdf_stream"
+        id="scap_org_ecomp_.certificateaudit" timestamp="2016-02-23T14:36:08">
+        <oscap-sce-xccdf-stream:script>#!/bin/sh
+            modified=$(apk audit --packages | grep '^ca-certificates')
+
+            if [ -z "$modified" ]; then
+            return $XCCDF_RESULT_PASS
+            else
+            echo "ca-certificates package has been modified"
+            return $XCCDF_RESULT_FAIL
+            fi
+        </oscap-sce-xccdf-stream:script>
+    </ds:extended-component>
     <ds:extended-component xmlns:oscap-sce-xccdf-stream="http://open-scap.org/page/SCE_xccdf_stream"
         id="scap_org_ecomp_.aslr" timestamp="2016-02-23T14:36:08">
         <oscap-sce-xccdf-stream:script>#!/bin/sh

--- a/gpos/xml/scap/ssg/content/ssg-chainguard-gpos-ds.xml
+++ b/gpos/xml/scap/ssg/content/ssg-chainguard-gpos-ds.xml
@@ -6391,8 +6391,8 @@
                         certificates.</ns0:description>
                     <ns0:description>
                         <html:pre>Script Verification:
-                            To manually verify, Ensure the ca-certificates package has been modified
-                            using apk audit</html:pre>
+                            To manually verify, Ensure the ca-certificates package has not been modified
+                            using apk audit or by ensuring the sha256 value matches the trusted value. </html:pre>
                     </ns0:description>
                     <ns0:check system="http://open-scap.org/page/SCE">
                         <ns0:check-import import-name="stdout" />

--- a/gpos/xml/scap/ssg/content/ssg-chainguard-gpos-ds.xml
+++ b/gpos/xml/scap/ssg/content/ssg-chainguard-gpos-ds.xml
@@ -84,19 +84,16 @@
                 <ns0:select idref="xccdf_._rule_V_203738" selected="true" />
                 <ns0:select idref="xccdf_._rule_V_203734" selected="true" />
                 <ns0:select idref="xccdf_._rule_V_203735" selected="true" />
-                <ns0:select idref="xccdf_._rule_V_203732" selected="true" />
                 <ns0:select idref="xccdf_._rule_V_203733" selected="true" />
                 <ns0:select idref="xccdf_._rule_V_203659" selected="true" />
                 <ns0:select idref="xccdf_._rule_V_203781" selected="true" />
                 <ns0:select idref="xccdf_._rule_V_203650" selected="true" />
                 <ns0:select idref="xccdf_._rule_V_203652" selected="true" />
                 <ns0:select idref="xccdf_._rule_V_203655" selected="true" />
-                <ns0:select idref="xccdf_._rule_V_203654" selected="true" />
                 <ns0:select idref="xccdf_._rule_V_203723" selected="true" />
                 <ns0:select idref="xccdf_._rule_V_203725" selected="true" />
                 <ns0:select idref="xccdf_._rule_V_203724" selected="true" />
                 <ns0:select idref="xccdf_._rule_V_203727" selected="true" />
-                <ns0:select idref="xccdf_._rule_V_203726" selected="true" />
                 <ns0:select idref="xccdf_._rule_V_203729" selected="true" />
                 <ns0:select idref="xccdf_._rule_V_203728" selected="true" />
                 <ns0:select idref="xccdf_._rule_V_203628" selected="true" />
@@ -121,7 +118,6 @@
                 <ns0:select idref="xccdf_._rule_V_203636" selected="true" />
                 <ns0:select idref="xccdf_._rule_V_203635" selected="true" />
                 <ns0:select idref="xccdf_._rule_V_203634" selected="true" />
-                <ns0:select idref="xccdf_._rule_V_203633" selected="true" />
                 <ns0:select idref="xccdf_._rule_V_203632" selected="true" />
                 <ns0:select idref="xccdf_._rule_V_203631" selected="true" />
                 <ns0:select idref="xccdf_._rule_V_203744" selected="true" />
@@ -1827,32 +1823,6 @@
                         Container Hardening Process Guide.</ns0:rationale>
                     <ns0:platform idref="cpe:/o:notapplicable"/>
                 </ns0:Rule>
-                <ns0:Rule id="xccdf_._rule_V_203662" selected="true" severity="medium">
-                    <ns0:title xml:lang="en">The operating system must employ automated mechanisms
-                        to determine the state of system components with regard to flaw remediation
-                        using the following frequency: continuously, where Endpoint Security
-                        Solution (ESS) is used; 30 days, for any additional internal network scans
-                        not covered by ESS; and annually, for external scans by Computer Network
-                        Defense Service Provider (CNDSP).</ns0:title>
-                    <ns0:description xml:lang="en">Without the use of automated mechanisms to scan
-                        for security flaws on a continuous and/or periodic basis, the operating
-                        system or other system components may remain vulnerable to the exploits
-                        presented by undetected software flaws.
-
-                        To support this requirement, the operating system may have an integrated
-                        solution incorporating continuous scanning using ESS and periodic scanning
-                        using other tools, as specified in the requirement.</ns0:description>
-                    <ns0:rationale>Container vulnerability scanning is performed by the team
-                        deploying the container and can be executed from the host operating system
-                        or against the container image when it is stored in a registry. Continuous
-                        scanning can be used to detect vulnerabilities that have been identified /
-                        announced since the previous scan and determine when updated images should
-                        be built and deployed in the environment.
-
-                        For more information on inherited controls for containers see the DISA
-                        Container Hardening Process Guide.</ns0:rationale>
-                    <ns0:platform idref="cpe:/o:notapplicable"/>
-                </ns0:Rule>
                 <ns0:Rule id="xccdf_._rule_V_203663" selected="true" severity="medium">
                     <ns0:title xml:lang="en">The operating system must generate error messages that
                         provide information necessary for corrective actions without revealing
@@ -2208,52 +2178,6 @@
                         provide the information in a format that can be extracted and used, allowing
                         the application performing the centralization of the log records to meet
                         this requirement.</ns0:description>
-                    <ns0:rationale>Auditing capabilities for Linux containers are implemented by the
-                        underlying host's audit configuration. In Linux, the auditing program auditd
-                        leverages multiple functions in the running kernel through the Linux
-                        Auditing System to capture runtime information such as process start / stop,
-                        opening sockets, and accessing files.
-
-                        Linux containers utilize the host's kernel, making it impossible to install
-                        and operate a separate auditing package inside the container itself.
-                        Instead, auditing information must be configured and collected through the
-                        audit configuration of the host.
-
-                        Once configured, logs of container actions are written to the host's audit
-                        log files and are readable only by the host superuser account. These logs
-                        must be collected from the host for incident response and reporting. Storage
-                        capacity limits, audit process monitoring, remote upload of logs and
-                        associated alerts are the responsibility of the host where the containers
-                        are running.
-
-                        For more information on inherited controls for containers see the DISA
-                        Container Hardening Process Guide.</ns0:rationale>
-                    <ns0:platform idref="cpe:/o:notapplicable"/>
-                </ns0:Rule>
-                <ns0:Rule id="xccdf_._rule_V_203612" selected="true" severity="medium">
-                    <ns0:title xml:lang="en">The operating system must shut down by default upon
-                        audit failure (unless availability is an overriding concern).</ns0:title>
-                    <ns0:description xml:lang="en">It is critical that when the operating system is
-                        at risk of failing to process audit logs as required, it takes action to
-                        mitigate the failure. Audit processing failures include: software/hardware
-                        errors; failures in the audit capturing mechanisms; and audit storage
-                        capacity being reached or exceeded. Responses to audit failure depend upon
-                        the nature of the failure mode.
-
-                        When availability is an overriding concern, other approved actions in
-                        response to an audit failure are as follows:
-
-                        1) If the failure was caused by the lack of audit record storage capacity,
-                        the operating system must continue generating audit records if possible
-                        (automatically restarting the audit service if necessary), overwriting the
-                        oldest audit records in a first-in-first-out manner.
-
-                        2) If audit records are sent to a centralized collection server and
-                        communication with this server is lost or the server fails, the operating
-                        system must queue audit records locally until communication is restored or
-                        until the audit records are retrieved manually. Upon restoration of the
-                        connection to the centralized collection server, action should be taken to
-                        synchronize the local audit data with the collection server.</ns0:description>
                     <ns0:rationale>Auditing capabilities for Linux containers are implemented by the
                         underlying host's audit configuration. In Linux, the auditing program auditd
                         leverages multiple functions in the running kernel through the Linux
@@ -4059,35 +3983,6 @@
                         <ns0:check-content-ref href="RemoteAccessServicesTest.xml" />
                     </ns0:check>
                 </ns0:Rule>
-                <ns0:Rule id="xccdf_._rule_V_203654" selected="true" severity="medium">
-                    <ns0:title xml:lang="en">The operating system must terminate all sessions and
-                        network connections related to nonlocal maintenance when nonlocal
-                        maintenance is completed.</ns0:title>
-                    <ns0:description xml:lang="en"> If a maintenance session or connection remains
-                        open after maintenance is completed, it may be hijacked by an attacker and
-                        used to compromise or damage the system.
-
-                        Some maintenance and test tools are either standalone devices with their own
-                        operating systems or are applications bundled with an operating system.
-                        Nonlocal maintenance and diagnostic activities are those activities
-                        conducted by individuals communicating through a network, either an external
-                        network (e.g., the Internet) or an internal network. Local maintenance and
-                        diagnostic activities are those activities carried out by individuals
-                        physically present at the information system or information system component
-                        and not communicating across a network connection.</ns0:description>
-                    <ns0:description>
-                        <html:pre>Script Verification:
-                            To manually verify, Ensure none of the following remote access packages
-                            exist in the folder /lib/apk/db/ Packages: openssh, openssh-server,
-                            openssh-client, openssh-sftp-server, dropbear, tigervnc,
-                            tigervnc-server, tigervnc-viewer, xrdp, xorgxrdp, vsftpd, proftpd,
-                            webmin, cockpit, cockpit-ws, cockpit-bridge, nfs-utils, samba,
-                            samba-server, samba-client, samba-common, rsh, telnet</html:pre>
-                    </ns0:description>
-                    <ns0:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-                        <ns0:check-content-ref href="RemoteAccessServicesTest.xml" />
-                    </ns0:check>
-                </ns0:Rule>
                 <ns0:Rule id="xccdf_._rule_V_203723" selected="true" severity="medium">
                     <ns0:title xml:lang="en">The operating system must require users to
                         re-authenticate for privilege escalation.</ns0:title>
@@ -4139,27 +4034,6 @@
                         purpose of configuring the device itself (management).
 
                         Requires further clarification from NIST.</ns0:description>
-                    <ns0:description>
-                        <html:pre>Script Verification:
-                            To manually verify, Ensure none of the following remote access packages
-                            exist in the folder /lib/apk/db/ Packages: openssh, openssh-server,
-                            openssh-client, openssh-sftp-server, dropbear, tigervnc,
-                            tigervnc-server, tigervnc-viewer, xrdp, xorgxrdp, vsftpd, proftpd,
-                            webmin, cockpit, cockpit-ws, cockpit-bridge, nfs-utils, samba,
-                            samba-server, samba-client, samba-common, rsh, telnet</html:pre>
-                    </ns0:description>
-                    <ns0:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-                        <ns0:check-content-ref href="RemoteAccessServicesTest.xml" />
-                    </ns0:check>
-                </ns0:Rule>
-                <ns0:Rule id="xccdf_._rule_V_203726" selected="true" severity="medium">
-                    <ns0:title xml:lang="en">The operating system must require devices to
-                        re-authenticate when changing authenticators.</ns0:title>
-                    <ns0:description xml:lang="en">Without re-authentication, devices may access
-                        resources or perform tasks for which they do not have authorization.
-
-                        When operating systems provide the capability to change device
-                        authenticators, it is critical the device re-authenticate.</ns0:description>
                     <ns0:description>
                         <html:pre>Script Verification:
                             To manually verify, Ensure none of the following remote access packages
@@ -5219,28 +5093,6 @@
                         <ns0:check-content-ref href="UserPasswordConfiguredTest.xml" />
                     </ns0:check>
                 </ns0:Rule>
-                <ns0:Rule id="xccdf_._rule_V_203732" selected="true" severity="medium">
-                    <ns0:title xml:lang="en">The operating system must allow the use of a temporary
-                        password for system logons with an immediate change to a permanent password.</ns0:title>
-                    <ns0:description xml:lang="en">Without providing this capability, an account may
-                        be created without a password. Non-repudiation cannot be guaranteed once an
-                        account is created if a user is not forced to change the temporary password
-                        upon initial logon.
-
-                        Temporary passwords are typically used to allow access when new accounts are
-                        created or passwords are changed. It is common practice for administrators
-                        to create temporary passwords for user accounts which allow the users to log
-                        on, yet force them to change the password once they have successfully
-                        authenticated.</ns0:description>
-                    <ns0:description>
-                        <html:pre>Script Verification:
-                            To manually verify, run command 'cat /etc/shadow and verify no password
-                            fields start with a '$' indicating a hashed password</html:pre>
-                    </ns0:description>
-                    <ns0:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-                        <ns0:check-content-ref href="UserPasswordConfiguredTest.xml" />
-                    </ns0:check>
-                </ns0:Rule>
                 <ns0:Rule id="xccdf_._rule_V_203733" selected="true" severity="medium">
                     <ns0:title xml:lang="en">The operating system must prohibit the use of cached
                         authenticators after one day.</ns0:title>
@@ -5379,24 +5231,6 @@
                         long it takes to crack a password. Use of more characters in a password
                         helps to exponentially increase the time and/or resources required to
                         compromise the password.</ns0:description>
-                    <ns0:description>
-                        <html:pre>Script Verification:
-                            To manually verify, run command 'cat /etc/shadow and verify no password
-                            fields start with a '$' indicating a hashed password</html:pre>
-                    </ns0:description>
-                    <ns0:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-                        <ns0:check-content-ref href="UserPasswordConfiguredTest.xml" />
-                    </ns0:check>
-                </ns0:Rule>
-                <ns0:Rule id="xccdf_._rule_V_203633" selected="true" severity="medium">
-                    <ns0:title xml:lang="en">The operating system must prohibit password reuse for a
-                        minimum of five generations.</ns0:title>
-                    <ns0:description xml:lang="en">Password complexity, or strength, is a measure of
-                        the effectiveness of a password in resisting attempts at guessing and
-                        brute-force attacks. If the information system or application allows the
-                        user to consecutively reuse their password when that password has exceeded
-                        its defined lifetime, the end result is a password that is not changed as
-                        per policy requirements.</ns0:description>
                     <ns0:description>
                         <html:pre>Script Verification:
                             To manually verify, run command 'cat /etc/shadow and verify no password

--- a/gpos/xml/scap/ssg/content/ssg-chainguard-gpos-ds.xml
+++ b/gpos/xml/scap/ssg/content/ssg-chainguard-gpos-ds.xml
@@ -18,7 +18,7 @@
                         uri="#scap_org.open-scap_cref_LibraryPermissionsTest" />
                     <cat:uri name="UserPasswordConfiguredTest.xml"
                         uri="#scap_org.open-scap_cref_UserPasswordConfiguredTest" />
-                    <cat:uri name="NoUsersCheck.xml" 
+                    <cat:uri name="NoUsersCheck.xml"
                         uri="#scap_org.open-scap_cref_NoUsersCheck" />
                     <cat:uri name="RemoteAccessServicesTest.xml"
                         uri="#scap_org.open-scap_cref_RemoteAccessServicesTest" />
@@ -26,7 +26,7 @@
                         uri="#scap_org.open-scap_cref_VarLogPermissionsTest" />
                     <cat:uri name="DetectOpenSslTest.xml"
                         uri="#scap_org.open-scap_cref_DetectOpenSslTest" />
-                    <cat:uri name="AslrCheck.sh" 
+                    <cat:uri name="AslrCheck.sh"
                         uri="#scap_org.open-scap_cref_AslrCheck" />
                 </cat:catalog>
             </ds:component-ref>
@@ -199,7 +199,7 @@
 
                         For more information on inherited controls for containers see the DISA
                         Container Hardening Process Guide.</ns0:rationale>
-                    <ns0:platform idref="cpe:/o:notapplicable"/>
+                    <ns0:platform idref="cpe:/o:notapplicable" />
 
                 </ns0:Rule>
                 <ns0:Rule id="xccdf_._rule_V_203746" selected="true" severity="high">
@@ -224,7 +224,7 @@
 
                         For more information on inherited controls for containers see the DISA
                         Container Hardening Process Guide.</ns0:rationale>
-                    <ns0:platform idref="cpe:/o:notapplicable"/>
+                    <ns0:platform idref="cpe:/o:notapplicable" />
                 </ns0:Rule>
                 <ns0:Rule id="xccdf_._rule_V_203745" selected="true" severity="high">
                     <ns0:title xml:lang="en">The operating system must implement cryptographic
@@ -248,7 +248,7 @@
 
                         For more information on inherited controls for containers see the DISA
                         Container Hardening Process Guide.</ns0:rationale>
-                    <ns0:platform idref="cpe:/o:notapplicable"/>
+                    <ns0:platform idref="cpe:/o:notapplicable" />
                 </ns0:Rule>
                 <ns0:Rule id="xccdf_._rule_V_203749" selected="true" severity="high">
                     <ns0:title xml:lang="en">The operating system must implement cryptographic
@@ -284,7 +284,7 @@
 
                         For more information on inherited controls for containers see the DISA
                         Container Hardening Process Guide.</ns0:rationale>
-                    <ns0:platform idref="cpe:/o:notapplicable"/>
+                    <ns0:platform idref="cpe:/o:notapplicable" />
                 </ns0:Rule>
                 <ns0:Rule id="xccdf_._rule_V_203748" selected="true" severity="high">
                     <ns0:title xml:lang="en">The operating system must protect the confidentiality
@@ -315,7 +315,7 @@
 
                         For more information on inherited controls for containers see the DISA
                         Container Hardening Process Guide.</ns0:rationale>
-                    <ns0:platform idref="cpe:/o:notapplicable"/>
+                    <ns0:platform idref="cpe:/o:notapplicable" />
                 </ns0:Rule>
                 <ns0:Rule id="xccdf_._rule_V_252688" selected="true" severity="high">
                     <ns0:title xml:lang="en">The operating system must protect the confidentiality
@@ -355,7 +355,7 @@
 
                         For more information on inherited controls for containers see the DISA
                         Container Hardening Process Guide.</ns0:rationale>
-                    <ns0:platform idref="cpe:/o:notapplicable"/>
+                    <ns0:platform idref="cpe:/o:notapplicable" />
                 </ns0:Rule>
                 <ns0:Rule id="xccdf_._rule_V_203714" selected="true" severity="low">
                     <ns0:title xml:lang="en">The operating system must record time stamps for audit
@@ -379,7 +379,7 @@
 
                         For more information on inherited controls for containers see the DISA
                         Container Hardening Process Guide.</ns0:rationale>
-                    <ns0:platform idref="cpe:/o:notapplicable"/>
+                    <ns0:platform idref="cpe:/o:notapplicable" />
                 </ns0:Rule>
                 <ns0:Rule id="xccdf_._rule_V_203708" selected="true" severity="low">
                     <ns0:title xml:lang="en">The operating system must provide a report generation
@@ -414,7 +414,7 @@
 
                         For more information on inherited controls for containers see the DISA
                         Container Hardening Process Guide.</ns0:rationale>
-                    <ns0:platform idref="cpe:/o:notapplicable"/>
+                    <ns0:platform idref="cpe:/o:notapplicable" />
                 </ns0:Rule>
                 <ns0:Rule id="xccdf_._rule_V_203702" selected="true" severity="low">
                     <ns0:title xml:lang="en">The operating system must immediately notify the SA and
@@ -443,7 +443,7 @@
 
                         For more information on inherited controls for containers see the DISA
                         Container Hardening Process Guide.</ns0:rationale>
-                    <ns0:platform idref="cpe:/o:notapplicable"/>
+                    <ns0:platform idref="cpe:/o:notapplicable" />
                 </ns0:Rule>
                 <ns0:Rule id="xccdf_._rule_V_203701" selected="true" severity="low">
                     <ns0:title xml:lang="en">The operating system must offload audit records onto a
@@ -473,7 +473,7 @@
 
                         For more information on inherited controls for containers see the DISA
                         Container Hardening Process Guide.</ns0:rationale>
-                    <ns0:platform idref="cpe:/o:notapplicable"/>
+                    <ns0:platform idref="cpe:/o:notapplicable" />
                 </ns0:Rule>
                 <ns0:Rule id="xccdf_._rule_V_203700" selected="true" severity="low">
                     <ns0:title xml:lang="en">The operating system must allocate audit record storage
@@ -505,7 +505,7 @@
 
                         For more information on inherited controls for containers see the DISA
                         Container Hardening Process Guide.</ns0:rationale>
-                    <ns0:platform idref="cpe:/o:notapplicable"/>
+                    <ns0:platform idref="cpe:/o:notapplicable" />
                 </ns0:Rule>
                 <ns0:Rule id="xccdf_._rule_V_203707" selected="true" severity="low">
                     <ns0:title xml:lang="en">The operating system must provide a report generation
@@ -540,7 +540,7 @@
 
                         For more information on inherited controls for containers see the DISA
                         Container Hardening Process Guide.</ns0:rationale>
-                    <ns0:platform idref="cpe:/o:notapplicable"/>
+                    <ns0:platform idref="cpe:/o:notapplicable" />
                 </ns0:Rule>
                 <ns0:Rule id="xccdf_._rule_V_203706" selected="true" severity="low">
                     <ns0:title xml:lang="en">The operating system must provide a report generation
@@ -575,7 +575,7 @@
 
                         For more information on inherited controls for containers see the DISA
                         Container Hardening Process Guide.</ns0:rationale>
-                    <ns0:platform idref="cpe:/o:notapplicable"/>
+                    <ns0:platform idref="cpe:/o:notapplicable" />
                 </ns0:Rule>
                 <ns0:Rule id="xccdf_._rule_V_203705" selected="true" severity="low">
                     <ns0:title xml:lang="en">The operating system must provide an audit reduction
@@ -611,7 +611,7 @@
 
                         For more information on inherited controls for containers see the DISA
                         Container Hardening Process Guide.</ns0:rationale>
-                    <ns0:platform idref="cpe:/o:notapplicable"/>
+                    <ns0:platform idref="cpe:/o:notapplicable" />
                 </ns0:Rule>
                 <ns0:Rule id="xccdf_._rule_V_203704" selected="true" severity="low">
                     <ns0:title xml:lang="en">The operating system must provide an audit reduction
@@ -646,7 +646,7 @@
 
                         For more information on inherited controls for containers see the DISA
                         Container Hardening Process Guide.</ns0:rationale>
-                    <ns0:platform idref="cpe:/o:notapplicable"/>
+                    <ns0:platform idref="cpe:/o:notapplicable" />
                 </ns0:Rule>
                 <ns0:Rule id="xccdf_._rule_V_203730" selected="true" severity="medium">
                     <ns0:title xml:lang="en">The operating system must authenticate peripherals
@@ -665,7 +665,7 @@
 
                         For more information on inherited controls for containers see the DISA
                         Container Hardening Process Guide.</ns0:rationale>
-                    <ns0:platform idref="cpe:/o:notapplicable"/>
+                    <ns0:platform idref="cpe:/o:notapplicable" />
                 </ns0:Rule>
                 <ns0:Rule id="xccdf_._rule_V_203731" selected="true" severity="medium">
                     <ns0:title xml:lang="en">The operating system must authenticate all endpoint
@@ -707,7 +707,7 @@
 
                         For more information on inherited controls for containers see the DISA
                         Container Hardening Process Guide.</ns0:rationale>
-                    <ns0:platform idref="cpe:/o:notapplicable"/>
+                    <ns0:platform idref="cpe:/o:notapplicable" />
                 </ns0:Rule>
                 <ns0:Rule id="xccdf_._rule_V_203658" selected="true" severity="medium">
                     <ns0:title xml:lang="en">The operating system must manage excess capacity,
@@ -743,7 +743,7 @@
 
                         For more information on inherited controls for containers see the DISA
                         Container Hardening Process Guide.</ns0:rationale>
-                    <ns0:platform idref="cpe:/o:notapplicable"/>
+                    <ns0:platform idref="cpe:/o:notapplicable" />
                 </ns0:Rule>
                 <ns0:Rule id="xccdf_._rule_V_203780" selected="true" severity="medium">
                     <ns0:title xml:lang="en">The operating system must be configured in accordance
@@ -772,7 +772,7 @@
 
                         For more information on inherited controls for containers see the DISA
                         Container Hardening Process Guide.</ns0:rationale>
-                    <ns0:platform idref="cpe:/o:notapplicable"/>
+                    <ns0:platform idref="cpe:/o:notapplicable" />
                 </ns0:Rule>
                 <ns0:Rule id="xccdf_._rule_V_203784" selected="true" severity="medium">
                     <ns0:title xml:lang="en">The operating system must enable an application
@@ -789,7 +789,7 @@
 
                         For more information on inherited controls for containers see the DISA
                         Container Hardening Process Guide.</ns0:rationale>
-                    <ns0:platform idref="cpe:/o:notapplicable"/>
+                    <ns0:platform idref="cpe:/o:notapplicable" />
                 </ns0:Rule>
                 <ns0:Rule id="xccdf_._rule_V_203651" selected="true" severity="medium">
                     <ns0:title xml:lang="en">The operating system must provide an audit reduction
@@ -822,7 +822,7 @@
 
                         For more information on inherited controls for containers see the DISA
                         Container Hardening Process Guide.</ns0:rationale>
-                    <ns0:platform idref="cpe:/o:notapplicable"/>
+                    <ns0:platform idref="cpe:/o:notapplicable" />
                 </ns0:Rule>
                 <ns0:Rule id="xccdf_._rule_V_203657" selected="true" severity="medium">
                     <ns0:title xml:lang="en">Operating systems must prevent unauthorized and
@@ -866,7 +866,7 @@
 
                         For more information on inherited controls for containers see the DISA
                         Container Hardening Process Guide.</ns0:rationale>
-                    <ns0:platform idref="cpe:/o:notapplicable"/>
+                    <ns0:platform idref="cpe:/o:notapplicable" />
                 </ns0:Rule>
                 <ns0:Rule id="xccdf_._rule_V_203656" selected="true" severity="medium">
                     <ns0:title xml:lang="en">The operating system must isolate security functions
@@ -913,7 +913,7 @@
 
                         For more information on inherited controls for containers see the DISA
                         Container Hardening Process Guide.</ns0:rationale>
-                    <ns0:platform idref="cpe:/o:notapplicable"/>
+                    <ns0:platform idref="cpe:/o:notapplicable" />
                 </ns0:Rule>
                 <ns0:Rule id="xccdf_._rule_V_203721" selected="true" severity="medium">
                     <ns0:title xml:lang="en">The operating system must prevent program execution in
@@ -955,7 +955,7 @@
 
                         For more information on inherited controls for containers see the DISA
                         Container Hardening Process Guide.</ns0:rationale>
-                    <ns0:platform idref="cpe:/o:notapplicable"/>
+                    <ns0:platform idref="cpe:/o:notapplicable" />
                 </ns0:Rule>
                 <ns0:Rule id="xccdf_._rule_V_203722" selected="true" severity="medium">
                     <ns0:title xml:lang="en">The operating system must employ a deny-all,
@@ -995,7 +995,7 @@
 
                         For more information on inherited controls for containers see the DISA
                         Container Hardening Process Guide.</ns0:rationale>
-                    <ns0:platform idref="cpe:/o:notapplicable"/>
+                    <ns0:platform idref="cpe:/o:notapplicable" />
                 </ns0:Rule>
                 <ns0:Rule id="xccdf_._rule_V_203620" selected="true" severity="medium">
                     <ns0:title xml:lang="en">The operating system must allow only the ISSM (or
@@ -1028,7 +1028,7 @@
 
                         For more information on inherited controls for containers see the DISA
                         Container Hardening Process Guide.</ns0:rationale>
-                    <ns0:platform idref="cpe:/o:notapplicable"/>
+                    <ns0:platform idref="cpe:/o:notapplicable" />
                 </ns0:Rule>
                 <ns0:Rule id="xccdf_._rule_V_203621" selected="true" severity="medium">
                     <ns0:title xml:lang="en">The operating system must generate audit records when
@@ -1060,7 +1060,7 @@
 
                         For more information on inherited controls for containers see the DISA
                         Container Hardening Process Guide.</ns0:rationale>
-                    <ns0:platform idref="cpe:/o:notapplicable"/>
+                    <ns0:platform idref="cpe:/o:notapplicable" />
                 </ns0:Rule>
                 <ns0:Rule id="xccdf_._rule_V_203755" selected="true" severity="medium">
                     <ns0:title xml:lang="en">The operating system must remove all software
@@ -1087,7 +1087,7 @@
 
                         For more information on inherited controls for containers see the DISA
                         Container Hardening Process Guide.</ns0:rationale>
-                    <ns0:platform idref="cpe:/o:notapplicable"/>
+                    <ns0:platform idref="cpe:/o:notapplicable" />
                 </ns0:Rule>
                 <ns0:Rule id="xccdf_._rule_V_203688" selected="true" severity="medium">
                     <ns0:title xml:lang="en">The operating system must protect wireless access to
@@ -1115,7 +1115,7 @@
 
                         For more information on inherited controls for containers see the DISA
                         Container Hardening Process Guide.</ns0:rationale>
-                    <ns0:platform idref="cpe:/o:notapplicable"/>
+                    <ns0:platform idref="cpe:/o:notapplicable" />
                 </ns0:Rule>
                 <ns0:Rule id="xccdf_._rule_V_203689" selected="true" severity="medium">
                     <ns0:title xml:lang="en">The operating system must protect wireless access to
@@ -1141,7 +1141,7 @@
 
                         For more information on inherited controls for containers see the DISA
                         Container Hardening Process Guide.</ns0:rationale>
-                    <ns0:platform idref="cpe:/o:notapplicable"/>
+                    <ns0:platform idref="cpe:/o:notapplicable" />
                 </ns0:Rule>
                 <ns0:Rule id="xccdf_._rule_V_203752" selected="true" severity="medium">
                     <ns0:title xml:lang="en">The operating system must behave in a predictable and
@@ -1177,7 +1177,7 @@
 
                         For more information on inherited controls for containers see the DISA
                         Container Hardening Process Guide.</ns0:rationale>
-                    <ns0:platform idref="cpe:/o:notapplicable"/>
+                    <ns0:platform idref="cpe:/o:notapplicable" />
                 </ns0:Rule>
                 <ns0:Rule id="xccdf_._rule_V_203638" selected="true" severity="medium">
                     <ns0:title xml:lang="en">The operating system must be configured to prohibit or
@@ -1210,7 +1210,7 @@
 
                         For more information on inherited controls for containers see the DISA
                         Container Hardening Process Guide.</ns0:rationale>
-                    <ns0:platform idref="cpe:/o:notapplicable"/>
+                    <ns0:platform idref="cpe:/o:notapplicable" />
                 </ns0:Rule>
                 <ns0:Rule id="xccdf_._rule_V_203637" selected="true" severity="medium">
                     <ns0:title xml:lang="en">The operating system must be configured to disable
@@ -1248,7 +1248,7 @@
 
                         For more information on inherited controls for containers see the DISA
                         Container Hardening Process Guide.</ns0:rationale>
-                    <ns0:platform idref="cpe:/o:notapplicable"/>
+                    <ns0:platform idref="cpe:/o:notapplicable" />
                 </ns0:Rule>
                 <ns0:Rule id="xccdf_._rule_V_203747" selected="true" severity="medium">
                     <ns0:title xml:lang="en">The operating system must protect against or limit the
@@ -1287,7 +1287,7 @@
 
                         For more information on inherited controls for containers see the DISA
                         Container Hardening Process Guide.</ns0:rationale>
-                    <ns0:platform idref="cpe:/o:notapplicable"/>
+                    <ns0:platform idref="cpe:/o:notapplicable" />
                 </ns0:Rule>
                 <ns0:Rule id="xccdf_._rule_V_203699" selected="true" severity="medium">
                     <ns0:title xml:lang="en">The operating system must provide the capability for
@@ -1324,7 +1324,7 @@
 
                         For more information on inherited controls for containers see the DISA
                         Container Hardening Process Guide.</ns0:rationale>
-                    <ns0:platform idref="cpe:/o:notapplicable"/>
+                    <ns0:platform idref="cpe:/o:notapplicable" />
                 </ns0:Rule>
                 <ns0:Rule id="xccdf_._rule_V_203694" selected="true" severity="medium">
                     <ns0:title xml:lang="en">The operating system must allow operating system admins
@@ -1364,7 +1364,7 @@
 
                         For more information on inherited controls for containers see the DISA
                         Container Hardening Process Guide.</ns0:rationale>
-                    <ns0:platform idref="cpe:/o:notapplicable"/>
+                    <ns0:platform idref="cpe:/o:notapplicable" />
                 </ns0:Rule>
                 <ns0:Rule id="xccdf_._rule_V_203697" selected="true" severity="medium">
                     <ns0:title xml:lang="en">The operating system must audit the execution of
@@ -1396,28 +1396,38 @@
 
                         For more information on inherited controls for containers see the DISA
                         Container Hardening Process Guide.</ns0:rationale>
-                    <ns0:platform idref="cpe:/o:notapplicable"/>
+                    <ns0:platform idref="cpe:/o:notapplicable" />
                 </ns0:Rule>
                 <ns0:Rule id="xccdf_._rule_V_203691" selected="true" severity="medium">
                     <ns0:title xml:lang="en">The operating system must notify system administrators
-                        and ISSOs of account enabling actions.</ns0:title>
+                        (SAs) and information
+                        system security officers (ISSOs) of account enabling actions.</ns0:title>
                     <ns0:description xml:lang="en">Once an attacker establishes access to a system,
-                        the attacker often attempts to create a persistent method of reestablishing
-                        access. One way to accomplish this is for the attacker to enable an existing
-                        disabled account. Sending notification of account enabling actions to the
-                        system administrator and ISSO is one method for mitigating this risk. Such a
-                        capability greatly reduces the risk that operating system accessibility will
-                        be negatively affected for extended periods of time and also provides
-                        logging that can be used for forensic purposes.
+                        the
+                        attacker often attempts to create a persistent method of reestablishing
+                        access. One
+                        way to accomplish this is for the attacker to enable an existing disabled
+                        account.
+                        Sending notification of account enabling actions to the SA and ISSO is one
+                        method
+                        for mitigating this risk. Such a capability greatly reduces the risk that
+                        operating
+                        system accessibility will be negatively affected for extended periods of
+                        time and
+                        also provides logging that can be used for forensic purposes.
 
-                        In order to detect and respond to events that affect user accessibility and
-                        application processing, operating systems must audit account enabling
-                        actions and, as required, notify the appropriate individuals so they can
-                        investigate the event.
+                        To detect and respond to events that affect user accessibility and
+                        application
+                        processing, operating systems must audit account enabling actions and, as
+                        required,
+                        notify the appropriate individuals so they can investigate the event.
 
                         To address access requirements, many operating systems can be integrated
-                        with enterprise-level authentication/access/auditing mechanisms that meet or
-                        exceed access control policy requirements.</ns0:description>
+                        with
+                        enterprise-level authentication/access/auditing mechanisms that meet or
+                        exceed
+                        access control policy
+                        requirements.</ns0:description>
                     <ns0:rationale>Auditing capabilities for Linux containers are implemented by the
                         underlying host's audit configuration. In Linux, the auditing program auditd
                         leverages multiple functions in the running kernel through the Linux
@@ -1438,7 +1448,7 @@
 
                         For more information on inherited controls for containers see the DISA
                         Container Hardening Process Guide.</ns0:rationale>
-                    <ns0:platform idref="cpe:/o:notapplicable"/>
+                    <ns0:platform idref="cpe:/o:notapplicable" />
                 </ns0:Rule>
                 <ns0:Rule id="xccdf_._rule_V_203690" selected="true" severity="medium">
                     <ns0:title xml:lang="en">The operating system must audit all account enabling
@@ -1472,7 +1482,7 @@
 
                         For more information on inherited controls for containers see the DISA
                         Container Hardening Process Guide.</ns0:rationale>
-                    <ns0:platform idref="cpe:/o:notapplicable"/>
+                    <ns0:platform idref="cpe:/o:notapplicable" />
                 </ns0:Rule>
                 <ns0:Rule id="xccdf_._rule_V_203693" selected="true" severity="medium">
                     <ns0:title xml:lang="en">The operating system must allow operating system admins
@@ -1511,7 +1521,7 @@
 
                         For more information on inherited controls for containers see the DISA
                         Container Hardening Process Guide.</ns0:rationale>
-                    <ns0:platform idref="cpe:/o:notapplicable"/>
+                    <ns0:platform idref="cpe:/o:notapplicable" />
                 </ns0:Rule>
                 <ns0:Rule id="xccdf_._rule_V_203593" selected="true" severity="medium">
                     <ns0:title xml:lang="en">The operating system must audit all account creations.</ns0:title>
@@ -1544,7 +1554,7 @@
 
                         For more information on inherited controls for containers see the DISA
                         Container Hardening Process Guide.</ns0:rationale>
-                    <ns0:platform idref="cpe:/o:notapplicable"/>
+                    <ns0:platform idref="cpe:/o:notapplicable" />
                 </ns0:Rule>
                 <ns0:Rule id="xccdf_._rule_V_203606" selected="true" severity="medium">
                     <ns0:title xml:lang="en">The operating system must produce audit records
@@ -1582,7 +1592,7 @@
 
                         For more information on inherited controls for containers see the DISA
                         Container Hardening Process Guide.</ns0:rationale>
-                    <ns0:platform idref="cpe:/o:notapplicable"/>
+                    <ns0:platform idref="cpe:/o:notapplicable" />
                 </ns0:Rule>
                 <ns0:Rule id="xccdf_._rule_V_203607" selected="true" severity="medium">
                     <ns0:title xml:lang="en">The operating system must produce audit records
@@ -1619,7 +1629,7 @@
 
                         For more information on inherited controls for containers see the DISA
                         Container Hardening Process Guide.</ns0:rationale>
-                    <ns0:platform idref="cpe:/o:notapplicable"/>
+                    <ns0:platform idref="cpe:/o:notapplicable" />
                 </ns0:Rule>
                 <ns0:Rule id="xccdf_._rule_V_203604" selected="true" severity="medium">
                     <ns0:title xml:lang="en">The operating system must produce audit records
@@ -1656,7 +1666,7 @@
 
                         For more information on inherited controls for containers see the DISA
                         Container Hardening Process Guide.</ns0:rationale>
-                    <ns0:platform idref="cpe:/o:notapplicable"/>
+                    <ns0:platform idref="cpe:/o:notapplicable" />
                 </ns0:Rule>
                 <ns0:Rule id="xccdf_._rule_V_203605" selected="true" severity="medium">
                     <ns0:title xml:lang="en">The operating system must produce audit records
@@ -1694,7 +1704,7 @@
 
                         For more information on inherited controls for containers see the DISA
                         Container Hardening Process Guide.</ns0:rationale>
-                    <ns0:platform idref="cpe:/o:notapplicable"/>
+                    <ns0:platform idref="cpe:/o:notapplicable" />
                 </ns0:Rule>
                 <ns0:Rule id="xccdf_._rule_V_203608" selected="true" severity="medium">
                     <ns0:title xml:lang="en">The operating system must produce audit records
@@ -1729,7 +1739,7 @@
 
                         For more information on inherited controls for containers see the DISA
                         Container Hardening Process Guide.</ns0:rationale>
-                    <ns0:platform idref="cpe:/o:notapplicable"/>
+                    <ns0:platform idref="cpe:/o:notapplicable" />
                 </ns0:Rule>
                 <ns0:Rule id="xccdf_._rule_V_203609" selected="true" severity="medium">
                     <ns0:title xml:lang="en">The operating system must generate audit records
@@ -1760,7 +1770,7 @@
 
                         For more information on inherited controls for containers see the DISA
                         Container Hardening Process Guide.</ns0:rationale>
-                    <ns0:platform idref="cpe:/o:notapplicable"/>
+                    <ns0:platform idref="cpe:/o:notapplicable" />
                 </ns0:Rule>
                 <ns0:Rule id="xccdf_._rule_V_203660" selected="true" severity="medium">
                     <ns0:title xml:lang="en">The operating system must fail to a secure state if
@@ -1798,7 +1808,7 @@
 
                         For more information on inherited controls for containers see the DISA
                         Container Hardening Process Guide.</ns0:rationale>
-                    <ns0:platform idref="cpe:/o:notapplicable"/>
+                    <ns0:platform idref="cpe:/o:notapplicable" />
                 </ns0:Rule>
                 <ns0:Rule id="xccdf_._rule_V_203661" selected="true" severity="medium">
                     <ns0:title xml:lang="en">The operating system must protect the confidentiality
@@ -1821,7 +1831,7 @@
 
                         For more information on inherited controls for containers see the DISA
                         Container Hardening Process Guide.</ns0:rationale>
-                    <ns0:platform idref="cpe:/o:notapplicable"/>
+                    <ns0:platform idref="cpe:/o:notapplicable" />
                 </ns0:Rule>
                 <ns0:Rule id="xccdf_._rule_V_203663" selected="true" severity="medium">
                     <ns0:title xml:lang="en">The operating system must generate error messages that
@@ -1860,7 +1870,7 @@
 
                         For more information on inherited controls for containers see the DISA
                         Container Hardening Process Guide.</ns0:rationale>
-                    <ns0:platform idref="cpe:/o:notapplicable"/>
+                    <ns0:platform idref="cpe:/o:notapplicable" />
                 </ns0:Rule>
                 <ns0:Rule id="xccdf_._rule_V_203666" selected="true" severity="medium">
                     <ns0:title xml:lang="en">The operating system must audit all account
@@ -1894,7 +1904,7 @@
 
                         For more information on inherited controls for containers see the DISA
                         Container Hardening Process Guide.</ns0:rationale>
-                    <ns0:platform idref="cpe:/o:notapplicable"/>
+                    <ns0:platform idref="cpe:/o:notapplicable" />
                 </ns0:Rule>
                 <ns0:Rule id="xccdf_._rule_V_203667" selected="true" severity="medium">
                     <ns0:title xml:lang="en">The operating system must audit all account disabling
@@ -1932,7 +1942,7 @@
 
                         For more information on inherited controls for containers see the DISA
                         Container Hardening Process Guide.</ns0:rationale>
-                    <ns0:platform idref="cpe:/o:notapplicable"/>
+                    <ns0:platform idref="cpe:/o:notapplicable" />
                 </ns0:Rule>
                 <ns0:Rule id="xccdf_._rule_V_203668" selected="true" severity="medium">
                     <ns0:title xml:lang="en">The operating system must audit all account removal
@@ -1970,7 +1980,7 @@
 
                         For more information on inherited controls for containers see the DISA
                         Container Hardening Process Guide.</ns0:rationale>
-                    <ns0:platform idref="cpe:/o:notapplicable"/>
+                    <ns0:platform idref="cpe:/o:notapplicable" />
                 </ns0:Rule>
                 <ns0:Rule id="xccdf_._rule_V_203756" selected="true" severity="medium">
                     <ns0:title xml:lang="en">The operating system must verify correct operation of
@@ -2008,7 +2018,7 @@
 
                         For more information on inherited controls for containers see the DISA
                         Container Hardening Process Guide.</ns0:rationale>
-                    <ns0:platform idref="cpe:/o:notapplicable"/>
+                    <ns0:platform idref="cpe:/o:notapplicable" />
                 </ns0:Rule>
                 <ns0:Rule id="xccdf_._rule_V_203757" selected="true" severity="medium">
                     <ns0:title xml:lang="en">The operating system must perform verification of the
@@ -2052,7 +2062,7 @@
 
                         For more information on inherited controls for containers see the DISA
                         Container Hardening Process Guide.</ns0:rationale>
-                    <ns0:platform idref="cpe:/o:notapplicable"/>
+                    <ns0:platform idref="cpe:/o:notapplicable" />
                 </ns0:Rule>
                 <ns0:Rule id="xccdf_._rule_V_203615" selected="true" severity="medium">
                     <ns0:title xml:lang="en">The operating system must use internal system clocks to
@@ -2076,7 +2086,7 @@
 
                         For more information on inherited controls for containers see the DISA
                         Container Hardening Process Guide.</ns0:rationale>
-                    <ns0:platform idref="cpe:/o:notapplicable"/>
+                    <ns0:platform idref="cpe:/o:notapplicable" />
                 </ns0:Rule>
                 <ns0:Rule id="xccdf_._rule_V_203614" selected="true" severity="medium">
                     <ns0:title xml:lang="en">The operating system must provide the capability to
@@ -2119,7 +2129,7 @@
 
                         For more information on inherited controls for containers see the DISA
                         Container Hardening Process Guide.</ns0:rationale>
-                    <ns0:platform idref="cpe:/o:notapplicable"/>
+                    <ns0:platform idref="cpe:/o:notapplicable" />
                 </ns0:Rule>
                 <ns0:Rule id="xccdf_._rule_V_203611" selected="true" severity="medium">
                     <ns0:title xml:lang="en">The operating system must alert the ISSO and SA (at a
@@ -2158,7 +2168,7 @@
 
                         For more information on inherited controls for containers see the DISA
                         Container Hardening Process Guide.</ns0:rationale>
-                    <ns0:platform idref="cpe:/o:notapplicable"/>
+                    <ns0:platform idref="cpe:/o:notapplicable" />
                 </ns0:Rule>
                 <ns0:Rule id="xccdf_._rule_V_203613" selected="true" severity="medium">
                     <ns0:title xml:lang="en">The operating system must provide the capability to
@@ -2198,7 +2208,7 @@
 
                         For more information on inherited controls for containers see the DISA
                         Container Hardening Process Guide.</ns0:rationale>
-                    <ns0:platform idref="cpe:/o:notapplicable"/>
+                    <ns0:platform idref="cpe:/o:notapplicable" />
                 </ns0:Rule>
                 <ns0:Rule id="xccdf_._rule_V_203619" selected="true" severity="medium">
                     <ns0:title xml:lang="en">The operating system must provide audit record
@@ -2251,7 +2261,7 @@
 
                         For more information on inherited controls for containers see the DISA
                         Container Hardening Process Guide.</ns0:rationale>
-                    <ns0:platform idref="cpe:/o:notapplicable"/>
+                    <ns0:platform idref="cpe:/o:notapplicable" />
                 </ns0:Rule>
                 <ns0:Rule id="xccdf_._rule_V_203618" selected="true" severity="medium">
                     <ns0:title xml:lang="en">The operating system must protect audit information
@@ -2288,7 +2298,7 @@
 
                         For more information on inherited controls for containers see the DISA
                         Container Hardening Process Guide.</ns0:rationale>
-                    <ns0:platform idref="cpe:/o:notapplicable"/>
+                    <ns0:platform idref="cpe:/o:notapplicable" />
                 </ns0:Rule>
                 <ns0:Rule id="xccdf_._rule_V_203673" selected="true" severity="medium">
                     <ns0:title xml:lang="en">The operating system must protect audit tools from
@@ -2327,7 +2337,7 @@
 
                         For more information on inherited controls for containers see the DISA
                         Container Hardening Process Guide.</ns0:rationale>
-                    <ns0:platform idref="cpe:/o:notapplicable"/>
+                    <ns0:platform idref="cpe:/o:notapplicable" />
                 </ns0:Rule>
                 <ns0:Rule id="xccdf_._rule_V_203672" selected="true" severity="medium">
                     <ns0:title xml:lang="en">The operating system must protect audit tools from
@@ -2366,7 +2376,7 @@
 
                         For more information on inherited controls for containers see the DISA
                         Container Hardening Process Guide.</ns0:rationale>
-                    <ns0:platform idref="cpe:/o:notapplicable"/>
+                    <ns0:platform idref="cpe:/o:notapplicable" />
                 </ns0:Rule>
                 <ns0:Rule id="xccdf_._rule_V_203671" selected="true" severity="medium">
                     <ns0:title xml:lang="en">The operating system must produce audit records
@@ -2396,7 +2406,7 @@
 
                         For more information on inherited controls for containers see the DISA
                         Container Hardening Process Guide.</ns0:rationale>
-                    <ns0:platform idref="cpe:/o:notapplicable"/>
+                    <ns0:platform idref="cpe:/o:notapplicable" />
                 </ns0:Rule>
                 <ns0:Rule id="xccdf_._rule_V_203670" selected="true" severity="medium">
                     <ns0:title xml:lang="en">The operating system must initiate session audits at
@@ -2425,7 +2435,7 @@
 
                         For more information on inherited controls for containers see the DISA
                         Container Hardening Process Guide.</ns0:rationale>
-                    <ns0:platform idref="cpe:/o:notapplicable"/>
+                    <ns0:platform idref="cpe:/o:notapplicable" />
                 </ns0:Rule>
                 <ns0:Rule id="xccdf_._rule_V_203677" selected="true" severity="medium">
                     <ns0:title xml:lang="en">In the event of a system failure, the operating system
@@ -2461,7 +2471,7 @@
 
                         For more information on inherited controls for containers see the DISA
                         Container Hardening Process Guide.</ns0:rationale>
-                    <ns0:platform idref="cpe:/o:notapplicable"/>
+                    <ns0:platform idref="cpe:/o:notapplicable" />
                 </ns0:Rule>
                 <ns0:Rule id="xccdf_._rule_V_203674" selected="true" severity="medium">
                     <ns0:title xml:lang="en">The operating system must protect audit tools from
@@ -2500,7 +2510,7 @@
 
                         For more information on inherited controls for containers see the DISA
                         Container Hardening Process Guide.</ns0:rationale>
-                    <ns0:platform idref="cpe:/o:notapplicable"/>
+                    <ns0:platform idref="cpe:/o:notapplicable" />
                 </ns0:Rule>
                 <ns0:Rule id="xccdf_._rule_V_203758" selected="true" severity="medium">
                     <ns0:title xml:lang="en">The operating system must shut down the information
@@ -2545,7 +2555,7 @@
 
                         For more information on inherited controls for containers see the DISA
                         Container Hardening Process Guide.</ns0:rationale>
-                    <ns0:platform idref="cpe:/o:notapplicable"/>
+                    <ns0:platform idref="cpe:/o:notapplicable" />
                 </ns0:Rule>
                 <ns0:Rule id="xccdf_._rule_V_203679" selected="true" severity="medium">
                     <ns0:title xml:lang="en">The operating system must notify system administrators
@@ -2583,7 +2593,7 @@
 
                         For more information on inherited controls for containers see the DISA
                         Container Hardening Process Guide.</ns0:rationale>
-                    <ns0:platform idref="cpe:/o:notapplicable"/>
+                    <ns0:platform idref="cpe:/o:notapplicable" />
                 </ns0:Rule>
                 <ns0:Rule id="xccdf_._rule_V_203678" selected="true" severity="medium">
                     <ns0:title xml:lang="en">The operating system must notify system administrators
@@ -2621,7 +2631,7 @@
 
                         For more information on inherited controls for containers see the DISA
                         Container Hardening Process Guide.</ns0:rationale>
-                    <ns0:platform idref="cpe:/o:notapplicable"/>
+                    <ns0:platform idref="cpe:/o:notapplicable" />
                 </ns0:Rule>
                 <ns0:Rule id="xccdf_._rule_V_203759" selected="true" severity="medium">
                     <ns0:title xml:lang="en">The operating system must generate audit records when
@@ -2653,7 +2663,7 @@
 
                         For more information on inherited controls for containers see the DISA
                         Container Hardening Process Guide.</ns0:rationale>
-                    <ns0:platform idref="cpe:/o:notapplicable"/>
+                    <ns0:platform idref="cpe:/o:notapplicable" />
                 </ns0:Rule>
                 <ns0:Rule id="xccdf_._rule_V_203772" selected="true" severity="medium">
                     <ns0:title xml:lang="en">The operating system must generate audit records when
@@ -2685,7 +2695,7 @@
 
                         For more information on inherited controls for containers see the DISA
                         Container Hardening Process Guide.</ns0:rationale>
-                    <ns0:platform idref="cpe:/o:notapplicable"/>
+                    <ns0:platform idref="cpe:/o:notapplicable" />
                 </ns0:Rule>
                 <ns0:Rule id="xccdf_._rule_V_203773" selected="true" severity="medium">
                     <ns0:title xml:lang="en">The operating system must generate audit records for
@@ -2717,7 +2727,7 @@
 
                         For more information on inherited controls for containers see the DISA
                         Container Hardening Process Guide.</ns0:rationale>
-                    <ns0:platform idref="cpe:/o:notapplicable"/>
+                    <ns0:platform idref="cpe:/o:notapplicable" />
                 </ns0:Rule>
                 <ns0:Rule id="xccdf_._rule_V_203770" selected="true" severity="medium">
                     <ns0:title xml:lang="en">The operating system must generate audit records
@@ -2749,7 +2759,7 @@
 
                         For more information on inherited controls for containers see the DISA
                         Container Hardening Process Guide.</ns0:rationale>
-                    <ns0:platform idref="cpe:/o:notapplicable"/>
+                    <ns0:platform idref="cpe:/o:notapplicable" />
                 </ns0:Rule>
                 <ns0:Rule id="xccdf_._rule_V_203777" selected="true" severity="medium">
                     <ns0:title xml:lang="en">The operating system must, at a minimum, off-load audit
@@ -2780,7 +2790,7 @@
 
                         For more information on inherited controls for containers see the DISA
                         Container Hardening Process Guide.</ns0:rationale>
-                    <ns0:platform idref="cpe:/o:notapplicable"/>
+                    <ns0:platform idref="cpe:/o:notapplicable" />
                 </ns0:Rule>
                 <ns0:Rule id="xccdf_._rule_V_203774" selected="true" severity="medium">
                     <ns0:title xml:lang="en">The operating system must generate audit records for
@@ -2812,7 +2822,7 @@
 
                         For more information on inherited controls for containers see the DISA
                         Container Hardening Process Guide.</ns0:rationale>
-                    <ns0:platform idref="cpe:/o:notapplicable"/>
+                    <ns0:platform idref="cpe:/o:notapplicable" />
                 </ns0:Rule>
                 <ns0:Rule id="xccdf_._rule_V_203775" selected="true" severity="medium">
                     <ns0:title xml:lang="en">The operating system must generate audit records for
@@ -2845,7 +2855,7 @@
 
                         For more information on inherited controls for containers see the DISA
                         Container Hardening Process Guide.</ns0:rationale>
-                    <ns0:platform idref="cpe:/o:notapplicable"/>
+                    <ns0:platform idref="cpe:/o:notapplicable" />
                 </ns0:Rule>
                 <ns0:Rule id="xccdf_._rule_V_203647" selected="true" severity="medium">
                     <ns0:title xml:lang="en">The operating system must uniquely identify peripherals
@@ -2864,7 +2874,7 @@
 
                         For more information on inherited controls for containers see the DISA
                         Container Hardening Process Guide.</ns0:rationale>
-                    <ns0:platform idref="cpe:/o:notapplicable"/>
+                    <ns0:platform idref="cpe:/o:notapplicable" />
                 </ns0:Rule>
                 <ns0:Rule id="xccdf_._rule_V_203710" selected="true" severity="medium">
                     <ns0:title xml:lang="en">The operating system must not alter original content or
@@ -2901,26 +2911,30 @@
 
                         For more information on inherited controls for containers see the DISA
                         Container Hardening Process Guide.</ns0:rationale>
-                    <ns0:platform idref="cpe:/o:notapplicable"/>
+                    <ns0:platform idref="cpe:/o:notapplicable" />
                 </ns0:Rule>
                 <ns0:Rule id="xccdf_._rule_V_203711" selected="true" severity="medium">
                     <ns0:title xml:lang="en">The operating system must, for networked systems,
-                        compare internal information system clocks at least every 24 hours with a
-                        server which is synchronized to one of the redundant United States Naval
-                        Observatory (USNO) time servers, or a time server designated for the
-                        appropriate DoD network (NIPRNet/SIPRNet), and/or the Global Positioning
-                        System (GPS).</ns0:title>
+                        compare internal information
+                        system clocks at least every 24 hours with an authoritative time source.</ns0:title>
                     <ns0:description xml:lang="en">Inaccurate time stamps make it more difficult to
                         correlate events and can lead to an inaccurate analysis. Determining the
-                        correct time a particular event occurred on a system is critical when
-                        conducting forensic analysis and investigating system events. Sources
-                        outside the configured acceptable allowance (drift) may be inaccurate.
+                        correct
+                        time a particular event occurred on a system is critical when conducting
+                        forensic
+                        analysis and investigating system events. Sources outside the configured
+                        acceptable
+                        allowance (drift) may be inaccurate.
+
                         Synchronizing internal information system clocks provides uniformity of time
-                        stamps for information systems with multiple system clocks and systems
-                        connected over a network.
+                        stamps
+                        for information systems with multiple system clocks and systems connected
+                        over a
+                        network.
 
                         Organizations should consider endpoints that may not have regular access to
-                        the authoritative time server (e.g., mobile, teleworking, and tactical
+                        the
+                        authoritative time server (e.g., mobile, teleworking, and tactical
                         endpoints).</ns0:description>
                     <ns0:rationale>Linux containers inherit the system time from the underlying host
                         - a separate time service is not operated within the container. The host
@@ -2932,7 +2946,7 @@
 
                         For more information on inherited controls for containers see the DISA
                         Container Hardening Process Guide.</ns0:rationale>
-                    <ns0:platform idref="cpe:/o:notapplicable"/>
+                    <ns0:platform idref="cpe:/o:notapplicable" />
                 </ns0:Rule>
                 <ns0:Rule id="xccdf_._rule_V_203712" selected="true" severity="medium">
                     <ns0:title xml:lang="en">The operating system must synchronize internal
@@ -2964,7 +2978,7 @@
 
                         For more information on inherited controls for containers see the DISA
                         Container Hardening Process Guide.</ns0:rationale>
-                    <ns0:platform idref="cpe:/o:notapplicable"/>
+                    <ns0:platform idref="cpe:/o:notapplicable" />
                 </ns0:Rule>
                 <ns0:Rule id="xccdf_._rule_V_203713" selected="true" severity="medium">
                     <ns0:title xml:lang="en">The operating system must record time stamps for audit
@@ -2995,7 +3009,7 @@
 
                         For more information on inherited controls for containers see the DISA
                         Container Hardening Process Guide.</ns0:rationale>
-                    <ns0:platform idref="cpe:/o:notapplicable"/>
+                    <ns0:platform idref="cpe:/o:notapplicable" />
                 </ns0:Rule>
                 <ns0:Rule id="xccdf_._rule_V_203715" selected="true" severity="medium">
                     <ns0:title xml:lang="en">The operating system must enforce dual authorization
@@ -3029,7 +3043,7 @@
 
                         For more information on inherited controls for containers see the DISA
                         Container Hardening Process Guide.</ns0:rationale>
-                    <ns0:platform idref="cpe:/o:notapplicable"/>
+                    <ns0:platform idref="cpe:/o:notapplicable" />
                 </ns0:Rule>
                 <ns0:Rule id="xccdf_._rule_V_203717" selected="true" severity="medium">
                     <ns0:title xml:lang="en">The operating system must notify designated personnel
@@ -3065,7 +3079,7 @@
 
                         For more information on inherited controls for containers see the DISA
                         Container Hardening Process Guide.</ns0:rationale>
-                    <ns0:platform idref="cpe:/o:notapplicable"/>
+                    <ns0:platform idref="cpe:/o:notapplicable" />
                 </ns0:Rule>
                 <ns0:Rule id="xccdf_._rule_V_203719" selected="true" severity="medium">
                     <ns0:title xml:lang="en">The operating system must audit the enforcement actions
@@ -3100,7 +3114,7 @@
 
                         For more information on inherited controls for containers see the DISA
                         Container Hardening Process Guide.</ns0:rationale>
-                    <ns0:platform idref="cpe:/o:notapplicable"/>
+                    <ns0:platform idref="cpe:/o:notapplicable" />
                 </ns0:Rule>
                 <ns0:Rule id="xccdf_._rule_V_203769" selected="true" severity="medium">
                     <ns0:title xml:lang="en">The audit system must be configured to audit the
@@ -3132,7 +3146,7 @@
 
                         For more information on inherited controls for containers see the DISA
                         Container Hardening Process Guide.</ns0:rationale>
-                    <ns0:platform idref="cpe:/o:notapplicable"/>
+                    <ns0:platform idref="cpe:/o:notapplicable" />
                 </ns0:Rule>
                 <ns0:Rule id="xccdf_._rule_V_203768" selected="true" severity="medium">
                     <ns0:title xml:lang="en">The operating system must generate audit records for
@@ -3164,7 +3178,7 @@
 
                         For more information on inherited controls for containers see the DISA
                         Container Hardening Process Guide.</ns0:rationale>
-                    <ns0:platform idref="cpe:/o:notapplicable"/>
+                    <ns0:platform idref="cpe:/o:notapplicable" />
                 </ns0:Rule>
                 <ns0:Rule id="xccdf_._rule_V_203765" selected="true" severity="medium">
                     <ns0:title xml:lang="en">The operating system must generate audit records when
@@ -3196,7 +3210,7 @@
 
                         For more information on inherited controls for containers see the DISA
                         Container Hardening Process Guide.</ns0:rationale>
-                    <ns0:platform idref="cpe:/o:notapplicable"/>
+                    <ns0:platform idref="cpe:/o:notapplicable" />
                 </ns0:Rule>
                 <ns0:Rule id="xccdf_._rule_V_203764" selected="true" severity="medium">
                     <ns0:title xml:lang="en">The operating system must generate audit records when
@@ -3228,7 +3242,7 @@
 
                         For more information on inherited controls for containers see the DISA
                         Container Hardening Process Guide.</ns0:rationale>
-                    <ns0:platform idref="cpe:/o:notapplicable"/>
+                    <ns0:platform idref="cpe:/o:notapplicable" />
                 </ns0:Rule>
                 <ns0:Rule id="xccdf_._rule_V_203767" selected="true" severity="medium">
                     <ns0:title xml:lang="en">The operating system must generate audit records when
@@ -3260,7 +3274,7 @@
 
                         For more information on inherited controls for containers see the DISA
                         Container Hardening Process Guide.</ns0:rationale>
-                    <ns0:platform idref="cpe:/o:notapplicable"/>
+                    <ns0:platform idref="cpe:/o:notapplicable" />
                 </ns0:Rule>
                 <ns0:Rule id="xccdf_._rule_V_203766" selected="true" severity="medium">
                     <ns0:title xml:lang="en">The operating system must generate audit records when
@@ -3292,7 +3306,7 @@
 
                         For more information on inherited controls for containers see the DISA
                         Container Hardening Process Guide.</ns0:rationale>
-                    <ns0:platform idref="cpe:/o:notapplicable"/>
+                    <ns0:platform idref="cpe:/o:notapplicable" />
                 </ns0:Rule>
                 <ns0:Rule id="xccdf_._rule_V_203761" selected="true" severity="medium">
                     <ns0:title xml:lang="en">The operating system must generate audit records when
@@ -3324,7 +3338,7 @@
 
                         For more information on inherited controls for containers see the DISA
                         Container Hardening Process Guide.</ns0:rationale>
-                    <ns0:platform idref="cpe:/o:notapplicable"/>
+                    <ns0:platform idref="cpe:/o:notapplicable" />
                 </ns0:Rule>
                 <ns0:Rule id="xccdf_._rule_V_203760" selected="true" severity="medium">
                     <ns0:title xml:lang="en">The operating system must generate audit records when
@@ -3357,7 +3371,7 @@
 
                         For more information on inherited controls for containers see the DISA
                         Container Hardening Process Guide.</ns0:rationale>
-                    <ns0:platform idref="cpe:/o:notapplicable"/>
+                    <ns0:platform idref="cpe:/o:notapplicable" />
                 </ns0:Rule>
                 <ns0:Rule id="xccdf_._rule_V_203763" selected="true" severity="medium">
                     <ns0:title xml:lang="en">The operating system must generate audit records when
@@ -3390,7 +3404,7 @@
 
                         For more information on inherited controls for containers see the DISA
                         Container Hardening Process Guide.</ns0:rationale>
-                    <ns0:platform idref="cpe:/o:notapplicable"/>
+                    <ns0:platform idref="cpe:/o:notapplicable" />
                 </ns0:Rule>
                 <ns0:Rule id="xccdf_._rule_V_203762" selected="true" severity="medium">
                     <ns0:title xml:lang="en">The operating system must generate audit records when
@@ -3422,7 +3436,7 @@
 
                         For more information on inherited controls for containers see the DISA
                         Container Hardening Process Guide.</ns0:rationale>
-                    <ns0:platform idref="cpe:/o:notapplicable"/>
+                    <ns0:platform idref="cpe:/o:notapplicable" />
                 </ns0:Rule>
                 <ns0:Rule id="xccdf_._rule_V_203709" selected="true" severity="medium">
                     <ns0:title xml:lang="en">The operating system must not alter original content or
@@ -3462,7 +3476,7 @@
 
                         For more information on inherited controls for containers see the DISA
                         Container Hardening Process Guide.</ns0:rationale>
-                    <ns0:platform idref="cpe:/o:notapplicable"/>
+                    <ns0:platform idref="cpe:/o:notapplicable" />
                 </ns0:Rule>
                 <ns0:Rule id="xccdf_._rule_V_203703" selected="true" severity="medium">
                     <ns0:title xml:lang="en">The operating system must provide an immediate
@@ -3497,7 +3511,7 @@
 
                         For more information on inherited controls for containers see the DISA
                         Container Hardening Process Guide.</ns0:rationale>
-                    <ns0:platform idref="cpe:/o:notapplicable"/>
+                    <ns0:platform idref="cpe:/o:notapplicable" />
                 </ns0:Rule>
             </ns0:Group>
             <ns0:Group id="xccdf_._group_Open_Ssl">
@@ -3985,7 +3999,7 @@
                 </ns0:Rule>
                 <ns0:Rule id="xccdf_._rule_V_203723" selected="true" severity="medium">
                     <ns0:title xml:lang="en">The operating system must require users to
-                        re-authenticate for privilege escalation.</ns0:title>
+                        reauthenticate for privilege escalation.</ns0:title>
                     <ns0:description xml:lang="en">Without re-authentication, users may access
                         resources or perform tasks for which they do not have authorization.
 
@@ -4006,34 +4020,33 @@
                 </ns0:Rule>
                 <ns0:Rule id="xccdf_._rule_V_203727" selected="true" severity="medium">
                     <ns0:title xml:lang="en">The operating system must implement multifactor
-                        authentication for remote access to privileged accounts in such a way that
-                        one of the factors is provided by a device separate from the system gaining
-                        access.</ns0:title>
-                    <ns0:description xml:lang="en">Using an authentication device, such as a CAC or
-                        token that is separate from the information system, ensures that even if the
-                        information system is compromised, that compromise will not affect
+                        authentication for remote access
+                        to privileged accounts in such a way that one of the factors is provided by
+                        a device
+                        separate from the system gaining access.</ns0:title>
+                    <ns0:description xml:lang="en">Using an authentication device, such as a common
+                        access card (CAC) or token that is separate from the information system, ensures
+                        that even if the information system is compromised, that compromise will not affect
                         credentials stored on the authentication device.
-
-                        Multifactor solutions that require devices separate from information systems
-                        gaining access include, for example, hardware tokens providing time-based or
-                        challenge-response authenticators and smart cards such as the U.S.
-                        Government Personal Identity Verification card and the DoD Common Access
-                        Card.
-
-                        A privileged account is defined as an information system account with
-                        authorizations of a privileged user.
-
-                        Remote access is access to DoD nonpublic information systems by an
-                        authorized user (or an information system) communicating through an
-                        external, non-organization-controlled network. Remote access methods
-                        include, for example, dial-up, broadband, and wireless.
-
-                        This requirement only applies to components where this is specific to the
-                        function of the device or has the concept of an organizational user (e.g.,
-                        VPN, proxy capability). This does not apply to authentication for the
-                        purpose of configuring the device itself (management).
-
-                        Requires further clarification from NIST.</ns0:description>
+        
+                        Multifactor solutions that require devices separate from information systems gaining
+                        access include, for example, hardware tokens providing time-based or
+                        challenge-response authenticators and smart cards such as the U.S. Government
+                        Personal Identity Verification (PIV) card and the DOD CAC.
+        
+                        A privileged account is defined as an information system account with authorizations
+                        of a privileged user.
+        
+                        Remote access is access to DOD nonpublic information systems by an authorized user
+                        (or an information system) communicating through an external,
+                        nonorganization-controlled network. Remote access methods include, for example,
+                        dial-up, broadband, and wireless.
+        
+                        This requirement only applies to components where this is specific to the function
+                        of the device or has the concept of an organizational user (e.g., VPN, proxy
+                        capability). This does not apply to authentication for the purpose of configuring
+                        the device itself
+                        (management).</ns0:description>
                     <ns0:description>
                         <html:pre>Script Verification:
                             To manually verify, Ensure none of the following remote access packages
@@ -4777,7 +4790,7 @@
                 </ns0:Rule>
                 <ns0:Rule id="xccdf_._rule_V_203646" selected="true" severity="medium">
                     <ns0:title xml:lang="en">The operating system must implement replay-resistant
-                        authentication mechanisms for network access to non-privileged accounts.</ns0:title>
+                        authentication mechanisms for network access to nonprivileged accounts.</ns0:title>
                     <ns0:description xml:lang="en">A replay attack may enable an unauthorized user
                         to gain access to the operating system. Authentication sessions between the
                         authenticator and the operating system validating the user credentials must
@@ -4811,28 +4824,40 @@
                     <ns0:title xml:lang="en">The operating system must require individuals to be
                         authenticated with an individual authenticator prior to using a group
                         authenticator.</ns0:title>
-                    <ns0:description xml:lang="en">To assure individual accountability and prevent
+                    <ns0:description xml:lang="en">To ensure individual accountability and prevent
                         unauthorized access, organizational users must be individually identified
-                        and authenticated.
+                        and
+                        authenticated.
 
                         A group authenticator is a generic account used by multiple individuals. Use
-                        of a group authenticator alone does not uniquely identify individual users.
-                        Examples of the group authenticator is the UNIX OS "root" user account, the
-                        Windows "Administrator" account, the "sa" account, or a "helpdesk" account.
-                        For example, the UNIX and Windows operating systems offer a 'switch user'
-                        capability allowing users to authenticate with their individual credentials
-                        and, when needed, 'switch' to the administrator role. This method provides
-                        for unique individual authentication prior to using a group authenticator.
-                        Users (and any processes acting on behalf of users) need to be uniquely
-                        identified and authenticated for all accesses other than those accesses
-                        explicitly identified and documented by the organization, which outlines
-                        specific user actions that can be performed on the operating system without
-                        identification or authentication.
+                        of a
+                        group authenticator alone does not uniquely identify individual users.
+                        Examples of
+                        the group authenticator is the Unix OS "root" user account, the Windows
+                        "Administrator" account, the "sa" account, or a "helpdesk" account.
 
+                        For example, the Unix and Windows operating systems offer a "switch user"
+                        capability
+                        allowing users to authenticate with their individual credentials and, when
+                        needed,
+                        "switch" to the administrator role. This method provides for unique
+                        individual
+                        authentication prior to using a group authenticator.
+
+                        Users (and any processes acting on behalf of users) need to be uniquely
+                        identified
+                        and authenticated for all accesses other than those accesses explicitly
+                        identified
+                        and documented by the organization, which outlines specific user actions
+                        that can be
+                        performed on the operating system without identification or authentication.
                         Requiring individuals to be authenticated with an individual authenticator
-                        prior to using a group authenticator allows for traceability of actions, as
-                        well as adding an additional level of protection of the actions that can be
-                        taken with group account knowledge.</ns0:description>
+                        prior to
+                        using a group authenticator allows for traceability of actions, as well as
+                        adding an
+                        additional level of protection of the actions that can be taken with group
+                        account
+                        knowledge.</ns0:description>
                     <ns0:description>
                         <html:pre>Script Verification:
                             To manually verify, Ensure none of the following remote access packages
@@ -4881,11 +4906,14 @@
                 <ns0:Rule id="xccdf_._rule_V_203642" selected="true" severity="medium">
                     <ns0:title xml:lang="en">The operating system must use multifactor
                         authentication for local access to privileged accounts.</ns0:title>
-                    <ns0:description xml:lang="en">To assure accountability and prevent
-                        unauthenticated access, privileged users must utilize multifactor
-                        authentication to prevent potential misuse and compromise of the system.
+                    <ns0:description xml:lang="en">To ensure accountability and prevent
+                        unauthenticated
+                        access, privileged users must utilize multifactor authentication to prevent
+                        potential misuse and compromise of the system.
+
                         Multifactor authentication is defined as using two or more factors to
-                        achieve authentication.
+                        achieve
+                        authentication.
 
                         Factors include:
                         1) Something you know (e.g., password/PIN);
@@ -4894,13 +4922,16 @@
                         3) Something you are (e.g., biometric).
 
                         A privileged account is defined as an operating system account with
-                        authorizations of a privileged user.
+                        authorizations
+                        of a privileged user.
 
                         Local access is defined as access to an organizational information system by
-                        a user (or process acting on behalf of a user) communicating through a
-                        direct connection without the use of a network.
+                        a user
+                        (or process acting on behalf of a user) communicating through a direct
+                        connection
+                        without the use of a network.
 
-                        The DoD CAC with DoD-approved PKI is an example of multifactor
+                        The DOD CAC with DOD-approved PKI is an example of multifactor
                         authentication.</ns0:description>
                     <ns0:description>
                         <html:pre>Script Verification:
@@ -4917,7 +4948,7 @@
                 </ns0:Rule>
                 <ns0:Rule id="xccdf_._rule_V_203643" selected="true" severity="medium">
                     <ns0:title xml:lang="en">The operating system must use multifactor
-                        authentication for local access to non-privileged accounts.</ns0:title>
+                        authentication for local access to nonprivileged accounts.</ns0:title>
                     <ns0:description xml:lang="en">To assure accountability, prevent unauthenticated
                         access, and prevent misuse of the system, non-privileged users must utilize
                         multifactor authentication for local access.
@@ -5037,19 +5068,27 @@
                     <ns0:description xml:lang="en">Changes to any software components can have
                         significant effects on the overall security of the operating system. This
                         requirement ensures the software has not been tampered with and that it has
-                        been provided by a trusted vendor.
+                        been
+                        provided by a trusted vendor.
 
                         Accordingly, patches, service packs, device drivers, or operating system
-                        components must be signed with a certificate recognized and approved by the
+                        components
+                        must be signed with a certificate recognized and approved by the
                         organization.
-
                         Verifying the authenticity of the software prior to installation validates
-                        the integrity of the patch or upgrade received from a vendor. This ensures
-                        the software has not been tampered with and that it has been provided by a
-                        trusted vendor. Self-signed certificates are disallowed by this requirement.
-                        The operating system should not have to verify the software again. This
-                        requirement does not mandate DoD certificates for this purpose; however, the
-                        certificate used to verify the software must be from an approved CA.</ns0:description>
+                        the
+                        integrity of the patch or upgrade received from a vendor. This ensures the
+                        software
+                        has not been tampered with and that it has been provided by a trusted
+                        vendor.
+                        Self-signed certificates are disallowed by this requirement. The operating
+                        system
+                        should not have to verify the software again. This requirement does not
+                        mandate DOD
+                        certificates for this purpose; however, the certificate used to verify the
+                        software
+                        must be from an approved
+                        CA.</ns0:description>
                     <ns0:description>
                         <html:pre>Script Verification:
                             To manually verify, ensure all repositories in /etc/apk/repositories/
@@ -5110,7 +5149,8 @@
                 </ns0:Rule>
                 <ns0:Rule id="xccdf_._rule_V_203628" selected="true" severity="medium">
                     <ns0:title xml:lang="en">The operating system must require the change of at
-                        least 50% of the total number of characters when passwords are changed.</ns0:title>
+                        least 50 percent of the total
+                        number of characters when passwords are changed.</ns0:title>
                     <ns0:description xml:lang="en"> If the operating system allows the user to
                         consecutively reuse extensive portions of passwords, this increases the
                         chances of password compromise by increasing the window of opportunity for
@@ -5135,16 +5175,22 @@
                 </ns0:Rule>
                 <ns0:Rule id="xccdf_._rule_V_203625" selected="true" severity="medium">
                     <ns0:title xml:lang="en">The operating system must enforce password complexity
-                        by requiring that at least one upper-case character be used.</ns0:title>
+                        by requiring that at least
+                        one uppercase character be used.</ns0:title>
                     <ns0:description xml:lang="en">Use of a complex password helps to increase the
-                        time and resources required to compromise the password. Password complexity,
-                        or strength, is a measure of the effectiveness of a password in resisting
-                        attempts at guessing and brute-force attacks.
+                        time
+                        and resources required to compromise the password. Password complexity, or
+                        strength,
+                        is a measure of the effectiveness of a password in resisting attempts at
+                        guessing
+                        and brute-force attacks.
 
                         Password complexity is one factor of several that determines how long it
-                        takes to crack a password. The more complex the password, the greater the
-                        number of possible combinations that need to be tested before the password
-                        is compromised.</ns0:description>
+                        takes to
+                        crack a password. The more complex the password, the greater the number of
+                        possible
+                        combinations that need to be tested before the password is
+                        compromised.</ns0:description>
                     <ns0:description>
                         <html:pre>Script Verification:
                             To manually verify, run command 'cat /etc/shadow and verify no password
@@ -5156,16 +5202,22 @@
                 </ns0:Rule>
                 <ns0:Rule id="xccdf_._rule_V_203626" selected="true" severity="medium">
                     <ns0:title xml:lang="en">The operating system must enforce password complexity
-                        by requiring that at least one lower-case character be used.</ns0:title>
+                        by requiring that at least
+                        one lowercase character be used.</ns0:title>
                     <ns0:description xml:lang="en">Use of a complex password helps to increase the
-                        time and resources required to compromise the password. Password complexity,
-                        or strength, is a measure of the effectiveness of a password in resisting
-                        attempts at guessing and brute-force attacks.
+                        time
+                        and resources required to compromise the password. Password complexity, or
+                        strength,
+                        is a measure of the effectiveness of a password in resisting attempts at
+                        guessing
+                        and brute-force attacks.
 
                         Password complexity is one factor of several that determines how long it
-                        takes to crack a password. The more complex the password, the greater the
-                        number of possible combinations that need to be tested before the password
-                        is compromised.</ns0:description>
+                        takes to
+                        crack a password. The more complex the password, the greater the number of
+                        possible
+                        combinations that need to be tested before the password is
+                        compromised.</ns0:description>
                     <ns0:description>
                         <html:pre>Script Verification:
                             To manually verify, run command 'cat /etc/shadow and verify no password
@@ -5244,10 +5296,13 @@
                     <ns0:title xml:lang="en">Operating systems must enforce a 60-day maximum
                         password lifetime restriction.</ns0:title>
                     <ns0:description xml:lang="en">Any password, no matter how complex, can
-                        eventually be cracked. Therefore, passwords need to be changed periodically.
-                        If the operating system does not limit the lifetime of passwords and force
-                        users to change their passwords, there is the risk that the operating system
-                        passwords could be compromised.</ns0:description>
+                        eventually
+                        be cracked; therefore, passwords need to be changed periodically. If the
+                        operating
+                        system does not limit the lifetime of passwords and force users to change
+                        their
+                        passwords, there is the risk that the operating system passwords could be
+                        compromised.</ns0:description>
                     <ns0:description>
                         <html:pre>Script Verification:
                             To manually verify, run command 'cat /etc/shadow and verify no password
@@ -5450,12 +5505,16 @@
                 </ns0:Rule>
                 <ns0:Rule id="xccdf_._rule_V_203725" selected="true" severity="medium">
                     <ns0:title xml:lang="en">The operating system must require users to
-                        re-authenticate when changing authenticators.</ns0:title>
-                    <ns0:description xml:lang="en">Without re-authentication, users may access
-                        resources or perform tasks for which they do not have authorization.
+                        reauthenticate when changing
+                        authenticators.</ns0:title>
+                    <ns0:description xml:lang="en">Without reauthentication, users may access
+                        resources
+                        or perform tasks for which they do not have authorization.
 
                         When operating systems provide the capability to change user authenticators,
-                        it is critical the user re-authenticate.</ns0:description>
+                        it is
+                        critical the user
+                        reauthenticate.</ns0:description>
                     <ns0:description>
                         <html:pre>Script Verification:
                             To manually verify, run command 'cat /etc/shadow and verify that no
@@ -5467,12 +5526,15 @@
                 </ns0:Rule>
                 <ns0:Rule id="xccdf_._rule_V_203724" selected="true" severity="medium">
                     <ns0:title xml:lang="en">The operating system must require users to
-                        re-authenticate when changing roles.</ns0:title>
-                    <ns0:description xml:lang="en">Without re-authentication, users may access
-                        resources or perform tasks for which they do not have authorization.
+                        reauthenticate when changing roles.</ns0:title>
+                    <ns0:description xml:lang="en">Without reauthentication, users may access
+                        resources
+                        or perform tasks for which they do not have authorization.
 
                         When operating systems provide the capability to change security roles, it
-                        is critical the user re-authenticate.</ns0:description>
+                        is
+                        critical the user
+                        reauthenticate.</ns0:description>
                     <ns0:description>
                         <html:pre>Script Verification:
                             To manually verify, run command 'cat /etc/shadow and verify that no
@@ -5884,508 +5946,527 @@
             </ns0:Group>
         </ns0:Benchmark>
     </ds:component>
-    <ds:extended-component xmlns:oscap-sce-xccdf-stream="http://open-scap.org/page/SCE_xccdf_stream" id="scap_org_ecomp_.aslr" timestamp="2016-02-23T14:36:08">
-    <oscap-sce-xccdf-stream:script>#!/bin/sh
-aslr_value=$(sysctl kernel.randomize_va_space | awk '{print $3}')
+    <ds:extended-component xmlns:oscap-sce-xccdf-stream="http://open-scap.org/page/SCE_xccdf_stream"
+        id="scap_org_ecomp_.aslr" timestamp="2016-02-23T14:36:08">
+        <oscap-sce-xccdf-stream:script>#!/bin/sh
+            aslr_value=$(sysctl kernel.randomize_va_space | awk '{print $3}')
 
-if [ $aslr_value -eq 2 ]; then
-    return $XCCDF_RESULT_PASS
-else 
-    echo "ASLR not configured correctly"
-    return $XCCDF_RESULT_FAIL
-fi
+            if [ $aslr_value -eq 2 ]; then
+            return $XCCDF_RESULT_PASS
+            else
+            echo "ASLR not configured correctly"
+            return $XCCDF_RESULT_FAIL
+            fi
 </oscap-sce-xccdf-stream:script>
-  </ds:extended-component>
+    </ds:extended-component>
     <ds:extended-component id="scap_org_ecomp_.openssl" timestamp="2024-05-29T12:00:00">
-  <oval_definitions xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5"
-    xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://oval.mitre.org/XMLSchema/oval-definitions-5 http://oval.mitre.org/language/download/schema/version5.10.1/ovaldefinition/complete/oval-definitions-schema.xsd">
-    <generator>
-      <oval:product_name>OpenSCAP</oval:product_name>
-      <oval:product_version>1.2.16</oval:product_version>
-      <oval:schema_version>5.11.1</oval:schema_version>
-      <oval:timestamp>2024-05-29T12:00:00</oval:timestamp>
-    </generator>
+        <oval_definitions xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5"
+            xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://oval.mitre.org/XMLSchema/oval-definitions-5 http://oval.mitre.org/language/download/schema/version5.10.1/ovaldefinition/complete/oval-definitions-schema.xsd">
+            <generator>
+                <oval:product_name>OpenSCAP</oval:product_name>
+                <oval:product_version>1.2.16</oval:product_version>
+                <oval:schema_version>5.11.1</oval:schema_version>
+                <oval:timestamp>2024-05-29T12:00:00</oval:timestamp>
+            </generator>
 
-    <definitions>
-      <definition id="oval:org.OpenSsl:def:1" version="1" class="compliance">
-        <metadata>
-          <title>Check for OpenSSL FIPS Packages</title>
-          <description>Ensure that the necessary OpenSSL FIPS packages and configuration files are
-            present.</description>
-          <reference source="CIS" />
-          <affected family="unix">
-            <platform>Alpine Linux</platform>
-          </affected>
-        </metadata>
-        <criteria>
-          <criterion comment="OpenSSL FIPS module configuration file exists"
-            test_ref="oval:org.OpenSsl:tst:1" />
-          <criterion comment="OpenSSL configuration file exists" test_ref="oval:org.OpenSsl:tst:2" />
-          <criterion comment="openssl-config-fipshardened package is installed"
-            test_ref="oval:org.OpenSsl:tst:3" />
-          <criterion comment="openssl-provider-fips package is installed"
-            test_ref="oval:org.OpenSsl:tst:4" />
-        </criteria>
-      </definition>
-    </definitions>
+            <definitions>
+                <definition id="oval:org.OpenSsl:def:1" version="1" class="compliance">
+                    <metadata>
+                        <title>Check for OpenSSL FIPS Packages</title>
+                        <description>Ensure that the necessary OpenSSL FIPS packages and
+                            configuration files are
+                            present.</description>
+                        <reference source="CIS" />
+                        <affected family="unix">
+                            <platform>Alpine Linux</platform>
+                        </affected>
+                    </metadata>
+                    <criteria>
+                        <criterion comment="OpenSSL FIPS module configuration file exists"
+                            test_ref="oval:org.OpenSsl:tst:1" />
+                        <criterion comment="OpenSSL configuration file exists"
+                            test_ref="oval:org.OpenSsl:tst:2" />
+                        <criterion comment="openssl-config-fipshardened package is installed"
+                            test_ref="oval:org.OpenSsl:tst:3" />
+                        <criterion comment="openssl-provider-fips package is installed"
+                            test_ref="oval:org.OpenSsl:tst:4" />
+                    </criteria>
+                </definition>
+            </definitions>
 
-    <tests>
-      <file_test id="oval:org.OpenSsl:tst:1" version="1" check="all"
-        check_existence="at_least_one_exists"
-        comment="OpenSSL FIPS module configuration file exists"
-        xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix">
-        <object object_ref="oval:org.OpenSsl:obj:1" />
-      </file_test>
+            <tests>
+                <file_test id="oval:org.OpenSsl:tst:1" version="1" check="all"
+                    check_existence="at_least_one_exists"
+                    comment="OpenSSL FIPS module configuration file exists"
+                    xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix">
+                    <object object_ref="oval:org.OpenSsl:obj:1" />
+                </file_test>
 
-      <file_test id="oval:org.OpenSsl:tst:2" version="1" check="all"
-        check_existence="at_least_one_exists" comment="OpenSSL configuration file exists"
-        xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix">
-        <object object_ref="oval:org.OpenSsl:obj:2" />
-      </file_test>
+                <file_test id="oval:org.OpenSsl:tst:2" version="1" check="all"
+                    check_existence="at_least_one_exists"
+                    comment="OpenSSL configuration file exists"
+                    xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix">
+                    <object object_ref="oval:org.OpenSsl:obj:2" />
+                </file_test>
 
-      <textfilecontent54_test id="oval:org.OpenSsl:tst:3" version="1" check="all"
-        check_existence="at_least_one_exists" comment="openssl-config-fipshardened package is installed"
-        xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent">
-        <object object_ref="oval:org.OpenSsl:obj:3" />
-      </textfilecontent54_test>
+                <textfilecontent54_test id="oval:org.OpenSsl:tst:3" version="1" check="all"
+                    check_existence="at_least_one_exists"
+                    comment="openssl-config-fipshardened package is installed"
+                    xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent">
+                    <object object_ref="oval:org.OpenSsl:obj:3" />
+                </textfilecontent54_test>
 
-      <textfilecontent54_test id="oval:org.OpenSsl:tst:4" version="1" check="all"
-        check_existence="at_least_one_exists"
-        comment="openssl-provider-fips package is installed"
-        xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent">
-        <object object_ref="oval:org.OpenSsl:obj:4" />
-      </textfilecontent54_test>
-    </tests>
+                <textfilecontent54_test id="oval:org.OpenSsl:tst:4" version="1" check="all"
+                    check_existence="at_least_one_exists"
+                    comment="openssl-provider-fips package is installed"
+                    xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent">
+                    <object object_ref="oval:org.OpenSsl:obj:4" />
+                </textfilecontent54_test>
+            </tests>
 
-    <objects>
+            <objects>
 
-      <file_object id="oval:org.OpenSsl:obj:1" version="1"
-        xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix">
-        <path>/etc/ssl</path>
-        <filename operation="pattern match">(?=.*fipsmodule).*</filename>
-      </file_object>
+                <file_object id="oval:org.OpenSsl:obj:1" version="1"
+                    xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix">
+                    <path>/etc/ssl</path>
+                    <filename operation="pattern match">(?=.*fipsmodule).*</filename>
+                </file_object>
 
-      <file_object id="oval:org.OpenSsl:obj:2" version="1"
-        xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix">
-        <path>/etc/ssl</path>
-        <filename operation="pattern match">(?=.*openssl).*</filename>
-      </file_object>
+                <file_object id="oval:org.OpenSsl:obj:2" version="1"
+                    xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix">
+                    <path>/etc/ssl</path>
+                    <filename operation="pattern match">(?=.*openssl).*</filename>
+                </file_object>
 
-      <textfilecontent54_object
-        xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent"
-        id="oval:org.OpenSsl:obj:3" version="1">
-        <path>/lib/apk/db</path>
-        <filename>installed</filename>
-        <pattern operation="pattern match">^P:openssl-config-fipshardened(-\d+\.\d+\.\d+)?$</pattern>
-        <instance datatype="int">1</instance>
-      </textfilecontent54_object>
+                <textfilecontent54_object
+                    xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent"
+                    id="oval:org.OpenSsl:obj:3" version="1">
+                    <path>/lib/apk/db</path>
+                    <filename>installed</filename>
+                    <pattern operation="pattern match">
+                        ^P:openssl-config-fipshardened(-\d+\.\d+\.\d+)?$</pattern>
+                    <instance datatype="int">1</instance>
+                </textfilecontent54_object>
 
-      <textfilecontent54_object
-        xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent"
-        id="oval:org.OpenSsl:obj:4" version="1">
-        <path>/lib/apk/db</path>
-        <filename>installed</filename>
-        <pattern operation="pattern match">^P:openssl-provider-fips(-\d+\.\d+\.\d+)?$</pattern>
-        <instance datatype="int">1</instance>
-      </textfilecontent54_object>
-    </objects>
-  </oval_definitions>
+                <textfilecontent54_object
+                    xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent"
+                    id="oval:org.OpenSsl:obj:4" version="1">
+                    <path>/lib/apk/db</path>
+                    <filename>installed</filename>
+                    <pattern operation="pattern match">^P:openssl-provider-fips(-\d+\.\d+\.\d+)?$</pattern>
+                    <instance datatype="int">1</instance>
+                </textfilecontent54_object>
+            </objects>
+        </oval_definitions>
 
-</ds:extended-component>
-<ds:extended-component id="scap_org_ecomp_.librarypermissions" timestamp="2024-05-29T12:00:00">
-  <oval_definitions xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5"
-    xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://oval.mitre.org/XMLSchema/oval-definitions-5 http://oval.mitre.org/language/download/schema/version5.10.1/ovaldefinition/complete/oval-definitions-schema.xsd">
-    <generator>
-      <oval:product_name>OpenSCAP</oval:product_name>
-      <oval:product_version>1.2.16</oval:product_version>
-      <oval:schema_version>5.11.1</oval:schema_version>
-      <oval:timestamp>2024-05-29T12:00:00</oval:timestamp>
-    </generator>
+    </ds:extended-component>
+    <ds:extended-component id="scap_org_ecomp_.librarypermissions" timestamp="2024-05-29T12:00:00">
+        <oval_definitions xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5"
+            xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://oval.mitre.org/XMLSchema/oval-definitions-5 http://oval.mitre.org/language/download/schema/version5.10.1/ovaldefinition/complete/oval-definitions-schema.xsd">
+            <generator>
+                <oval:product_name>OpenSCAP</oval:product_name>
+                <oval:product_version>1.2.16</oval:product_version>
+                <oval:schema_version>5.11.1</oval:schema_version>
+                <oval:timestamp>2024-05-29T12:00:00</oval:timestamp>
+            </generator>
 
-    <definitions>
+            <definitions>
 
-      <definition id="oval:org.LibraryPermissions:def:2" version="1" class="compliance">
-        <metadata>
-          <title>Check Library Permissions</title>
-          <description>Ensure all libraries in /usr/lib have root:root permissions.</description>
-          <reference source="CIS" />
-          <affected family="unix">
-            <platform>Alpine Linux</platform>
-          </affected>
-        </metadata>
-        <criteria operator="AND">
-          <criterion comment="All files in /usr/lib have root:root permissions"
-            test_ref="oval:org.LibraryPermissions:tst:1" />
-          <criterion comment="All directories in /usr/lib have root:root permissions"
-            test_ref="oval:org.LibraryPermissions:tst:2" />
-        </criteria>
-      </definition>
-    </definitions>
+                <definition id="oval:org.LibraryPermissions:def:2" version="1" class="compliance">
+                    <metadata>
+                        <title>Check Library Permissions</title>
+                        <description>Ensure all libraries in /usr/lib have root:root permissions.</description>
+                        <reference source="CIS" />
+                        <affected family="unix">
+                            <platform>Alpine Linux</platform>
+                        </affected>
+                    </metadata>
+                    <criteria operator="AND">
+                        <criterion comment="All files in /usr/lib have root:root permissions"
+                            test_ref="oval:org.LibraryPermissions:tst:1" />
+                        <criterion comment="All directories in /usr/lib have root:root permissions"
+                            test_ref="oval:org.LibraryPermissions:tst:2" />
+                    </criteria>
+                </definition>
+            </definitions>
 
-    <tests>
-      <unix:file_test id="oval:org.LibraryPermissions:tst:1" version="1" check="all"
-        check_existence="at_least_one_exists" comment="Check existence of /usr/lib directory"
-        xmlns:unix="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix">
-        <unix:object object_ref="oval:org.LibraryPermissions:obj:1" />
+            <tests>
+                <unix:file_test id="oval:org.LibraryPermissions:tst:1" version="1" check="all"
+                    check_existence="at_least_one_exists"
+                    comment="Check existence of /usr/lib directory"
+                    xmlns:unix="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix">
+                    <unix:object object_ref="oval:org.LibraryPermissions:obj:1" />
 
-        <unix:state state_ref="oval:org.LibraryPermissions:ste:1" />
-      </unix:file_test>
-      <unix:file_test id="oval:org.LibraryPermissions:tst:2" version="1" check="all"
-        check_existence="at_least_one_exists" comment="Check existence of /usr/lib directory"
-        xmlns:unix="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix">
-        <unix:object object_ref="oval:org.LibraryPermissions:obj:2" />
-        <unix:state state_ref="oval:org.LibraryPermissions:ste:1" />
-      </unix:file_test>
-    </tests>
+                    <unix:state state_ref="oval:org.LibraryPermissions:ste:1" />
+                </unix:file_test>
+                <unix:file_test id="oval:org.LibraryPermissions:tst:2" version="1" check="all"
+                    check_existence="at_least_one_exists"
+                    comment="Check existence of /usr/lib directory"
+                    xmlns:unix="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix">
+                    <unix:object object_ref="oval:org.LibraryPermissions:obj:2" />
+                    <unix:state state_ref="oval:org.LibraryPermissions:ste:1" />
+                </unix:file_test>
+            </tests>
 
-    <objects>
+            <objects>
 
-      <unix:file_object id="oval:org.LibraryPermissions:obj:1" version="1"
-        xmlns:unix="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix">
-        <unix:path>/usr/lib</unix:path>
-        <!-- <unix:filename xsi:nil="true"/> -->
-        <unix:filename operation="pattern match">^.*$</unix:filename>
-      </unix:file_object>
-      <unix:file_object id="oval:org.LibraryPermissions:obj:2" version="1"
-        xmlns:unix="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix">
-        <unix:behaviors recurse="directories" recurse_direction="down" />
-        <unix:path>/usr/lib</unix:path>
-        <unix:filename operation="pattern match">^.*$</unix:filename>
-      </unix:file_object>
+                <unix:file_object id="oval:org.LibraryPermissions:obj:1" version="1"
+                    xmlns:unix="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix">
+                    <unix:path>/usr/lib</unix:path>
+                    <!-- <unix:filename xsi:nil="true"/> -->
+                    <unix:filename operation="pattern match">^.*$</unix:filename>
+                </unix:file_object>
+                <unix:file_object id="oval:org.LibraryPermissions:obj:2" version="1"
+                    xmlns:unix="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix">
+                    <unix:behaviors recurse="directories" recurse_direction="down" />
+                    <unix:path>/usr/lib</unix:path>
+                    <unix:filename operation="pattern match">^.*$</unix:filename>
+                </unix:file_object>
 
-    </objects>
+            </objects>
 
-    <states>
-      <unix:file_state id="oval:org.LibraryPermissions:ste:1" version="1"
-        xmlns:unix="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix">
-        <unix:group_id datatype="int">0</unix:group_id>
-        <unix:user_id datatype="int">0</unix:user_id>
-      </unix:file_state>
+            <states>
+                <unix:file_state id="oval:org.LibraryPermissions:ste:1" version="1"
+                    xmlns:unix="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix">
+                    <unix:group_id datatype="int">0</unix:group_id>
+                    <unix:user_id datatype="int">0</unix:user_id>
+                </unix:file_state>
 
-    </states>
-  </oval_definitions>
-</ds:extended-component>
-<ds:extended-component id="scap_org_ecomp_.nousers" timestamp="2024-05-29T12:00:00">
-  <oval_definitions xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5"
-    xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://oval.mitre.org/XMLSchema/oval-definitions-5 http://oval.mitre.org/language/download/schema/version5.10.1/ovaldefinition/complete/oval-definitions-schema.xsd">
-    <generator>
-      <oval:product_name>OpenSCAP</oval:product_name>
-      <oval:product_version>1.2.16</oval:product_version>
-      <oval:schema_version>5.11.1</oval:schema_version>
-      <oval:timestamp>2024-05-29T12:00:00</oval:timestamp>
-    </generator>
+            </states>
+        </oval_definitions>
+    </ds:extended-component>
+    <ds:extended-component id="scap_org_ecomp_.nousers" timestamp="2024-05-29T12:00:00">
+        <oval_definitions xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5"
+            xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://oval.mitre.org/XMLSchema/oval-definitions-5 http://oval.mitre.org/language/download/schema/version5.10.1/ovaldefinition/complete/oval-definitions-schema.xsd">
+            <generator>
+                <oval:product_name>OpenSCAP</oval:product_name>
+                <oval:product_version>1.2.16</oval:product_version>
+                <oval:schema_version>5.11.1</oval:schema_version>
+                <oval:timestamp>2024-05-29T12:00:00</oval:timestamp>
+            </generator>
 
-    <definitions>
-      <definition id="oval:org.NoUsers:def:1" version="1" class="compliance">
-        <metadata>
-          <title>Check for Unauthorized Users in /etc/shadow</title>
-          <description>Ensure there are no unauthorized users in the /etc/shadow file below the
-            'nobody' line.</description>
-          <reference source="CIS" />
-          <affected family="unix">
-            <platform>Alpine Linux</platform>
-          </affected>
-        </metadata>
-        <criteria operator="AND">
-          <criterion comment="Check that the 'nobody' line is present"
-            test_ref="oval:org.NoUsers:tst:1" />
-          <criterion comment="Check for unauthorized users after the 'nobody' line"
-            test_ref="oval:org.NoUsers:tst:2" />
-        </criteria>
-      </definition>
-    </definitions>
+            <definitions>
+                <definition id="oval:org.NoUsers:def:1" version="1" class="compliance">
+                    <metadata>
+                        <title>Check for Unauthorized Users in /etc/shadow</title>
+                        <description>Ensure there are no unauthorized users in the /etc/shadow file
+                            below the
+                            'nobody' line.</description>
+                        <reference source="CIS" />
+                        <affected family="unix">
+                            <platform>Alpine Linux</platform>
+                        </affected>
+                    </metadata>
+                    <criteria operator="AND">
+                        <criterion comment="Check that the 'nobody' line is present"
+                            test_ref="oval:org.NoUsers:tst:1" />
+                        <criterion comment="Check for unauthorized users after the 'nobody' line"
+                            test_ref="oval:org.NoUsers:tst:2" />
+                    </criteria>
+                </definition>
+            </definitions>
 
-    <tests>
-      <!-- Test to check the presence of 'nobody' line -->
-      <textfilecontent54_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent"
-        check="all" check_existence="at_least_one_exists"
-        comment="Check presence of 'nobody' line in /etc/shadow" id="oval:org.NoUsers:tst:1"
-        version="1">
-        <object object_ref="oval:org.NoUsers:obj:1" />
-      </textfilecontent54_test>
+            <tests>
+                <!-- Test to check the presence of 'nobody' line -->
+                <textfilecontent54_test
+                    xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent"
+                    check="all" check_existence="at_least_one_exists"
+                    comment="Check presence of 'nobody' line in /etc/shadow"
+                    id="oval:org.NoUsers:tst:1"
+                    version="1">
+                    <object object_ref="oval:org.NoUsers:obj:1" />
+                </textfilecontent54_test>
 
-      <!-- Test to check for any lines after 'nobody' -->
-      <textfilecontent54_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent"
-        check="all" check_existence="none_exist"
-        comment="Check for unauthorized users after the 'nobody' line in /etc/shadow"
-        id="oval:org.NoUsers:tst:2" version="1">
-        <object object_ref="oval:org.NoUsers:obj:2" />
-      </textfilecontent54_test>
-    </tests>
+                <!-- Test to check for any lines after 'nobody' -->
+                <textfilecontent54_test
+                    xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent"
+                    check="all" check_existence="none_exist"
+                    comment="Check for unauthorized users after the 'nobody' line in /etc/shadow"
+                    id="oval:org.NoUsers:tst:2" version="1">
+                    <object object_ref="oval:org.NoUsers:obj:2" />
+                </textfilecontent54_test>
+            </tests>
 
-    <objects>
-      <!-- Object to find the 'nobody' line -->
-      <textfilecontent54_object
-        xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent"
-        id="oval:org.NoUsers:obj:1" version="1">
-        <path>/etc</path>
-        <filename>shadow</filename>
-        <pattern operation="pattern match">^nobody:.*</pattern>
-        <instance datatype="int">1</instance>
-      </textfilecontent54_object>
+            <objects>
+                <!-- Object to find the 'nobody' line -->
+                <textfilecontent54_object
+                    xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent"
+                    id="oval:org.NoUsers:obj:1" version="1">
+                    <path>/etc</path>
+                    <filename>shadow</filename>
+                    <pattern operation="pattern match">^nobody:.*</pattern>
+                    <instance datatype="int">1</instance>
+                </textfilecontent54_object>
 
-      <!-- Object to find any lines after 'nobody' -->
-      <textfilecontent54_object
-        xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent"
-        id="oval:org.NoUsers:obj:2" version="1">
-        <path>/etc</path>
-        <filename>shadow</filename>
-        <pattern operation="pattern match">^nobody:.*\n(.+)</pattern>
-        <instance datatype="int">1</instance>
-      </textfilecontent54_object>
-    </objects>
+                <!-- Object to find any lines after 'nobody' -->
+                <textfilecontent54_object
+                    xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent"
+                    id="oval:org.NoUsers:obj:2" version="1">
+                    <path>/etc</path>
+                    <filename>shadow</filename>
+                    <pattern operation="pattern match">^nobody:.*\n(.+)</pattern>
+                    <instance datatype="int">1</instance>
+                </textfilecontent54_object>
+            </objects>
 
-    <states>
-      <!-- No specific states needed for this NoUsers -->
-      <textfilecontent54_state
-        xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent"
-        id="oval:my_test:ste:1" version="1">
-        <subexpression>20230201</subexpression>
-      </textfilecontent54_state>
-    </states>
-  </oval_definitions>
+            <states>
+                <!-- No specific states needed for this NoUsers -->
+                <textfilecontent54_state
+                    xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent"
+                    id="oval:my_test:ste:1" version="1">
+                    <subexpression>20230201</subexpression>
+                </textfilecontent54_state>
+            </states>
+        </oval_definitions>
 
-</ds:extended-component>
-<ds:extended-component id="scap_org_ecomp_.packagesignaturecheck" timestamp="2024-05-29T12:00:00">
-  <oval_definitions xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5"
-    xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://oval.mitre.org/XMLSchema/oval-definitions-5 http://oval.mitre.org/language/download/schema/version5.10.1/ovaldefinition/complete/oval-definitions-schema.xsd">
-    <generator>
-      <oval:product_name>Custom</oval:product_name>
-      <oval:product_version>1.2.16</oval:product_version>
-      <oval:schema_version>5.11.1</oval:schema_version>
-      <oval:timestamp>2024-05-30T12:00:00</oval:timestamp>
-    </generator>
+    </ds:extended-component>
+    <ds:extended-component id="scap_org_ecomp_.packagesignaturecheck"
+        timestamp="2024-05-29T12:00:00">
+        <oval_definitions xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5"
+            xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://oval.mitre.org/XMLSchema/oval-definitions-5 http://oval.mitre.org/language/download/schema/version5.10.1/ovaldefinition/complete/oval-definitions-schema.xsd">
+            <generator>
+                <oval:product_name>Custom</oval:product_name>
+                <oval:product_version>1.2.16</oval:product_version>
+                <oval:schema_version>5.11.1</oval:schema_version>
+                <oval:timestamp>2024-05-30T12:00:00</oval:timestamp>
+            </generator>
 
-    <definitions>
-      <definition id="oval:org.PackageSignature:def:1" version="1" class="compliance">
-        <metadata>
-          <title>Check /etc/apk/repositories for HTTPS</title>
-          <description>Ensure all repositories in /etc/apk/repositories use HTTPS.</description>
-          <reference source="Custom" />
-          <affected family="unix">
-            <platform>Alpine Linux</platform>
-          </affected>
-        </metadata>
-        <criteria operator="AND">
-          <criterion comment="Ensure all repositories in /etc/apk/repositories use HTTPS"
-            test_ref="oval:org.PackageSignature:tst:1" />
-        </criteria>
-      </definition>
-    </definitions>
+            <definitions>
+                <definition id="oval:org.PackageSignature:def:1" version="1" class="compliance">
+                    <metadata>
+                        <title>Check /etc/apk/repositories for HTTPS</title>
+                        <description>Ensure all repositories in /etc/apk/repositories use HTTPS.</description>
+                        <reference source="Custom" />
+                        <affected family="unix">
+                            <platform>Alpine Linux</platform>
+                        </affected>
+                    </metadata>
+                    <criteria operator="AND">
+                        <criterion
+                            comment="Ensure all repositories in /etc/apk/repositories use HTTPS"
+                            test_ref="oval:org.PackageSignature:tst:1" />
+                    </criteria>
+                </definition>
+            </definitions>
 
-    <tests>
-      <unix:file_test id="oval:org.PackageSignature:tst:1" version="1" check="all"
-        check_existence="none_exist" comment="Check existence of /usr/lib directory"
-        xmlns:unix="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix">
-        <unix:object object_ref="oval:org.PackageSignature:obj:1" />
-      </unix:file_test>
-    </tests>
+            <tests>
+                <unix:file_test id="oval:org.PackageSignature:tst:1" version="1" check="all"
+                    check_existence="none_exist" comment="Check existence of /usr/lib directory"
+                    xmlns:unix="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix">
+                    <unix:object object_ref="oval:org.PackageSignature:obj:1" />
+                </unix:file_test>
+            </tests>
 
-    <objects>
-      <unix:file_object id="oval:org.PackageSignature:obj:1" version="1"
-        xmlns:unix="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix">
-        <unix:path>etc/apk/repositories</unix:path>
-        <unix:filename operation="pattern match">^(?!.*https://).*</unix:filename>
-      </unix:file_object>
-    </objects>
+            <objects>
+                <unix:file_object id="oval:org.PackageSignature:obj:1" version="1"
+                    xmlns:unix="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix">
+                    <unix:path>etc/apk/repositories</unix:path>
+                    <unix:filename operation="pattern match">^(?!.*https://).*</unix:filename>
+                </unix:file_object>
+            </objects>
 
-    <states>
-      <textfilecontent54_state
-        xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent"
-        id="oval:my_test:ste:1" version="1">
-        <subexpression>2024-05-29T12:00:00</subexpression>
-      </textfilecontent54_state>
-    </states>
-  </oval_definitions>
+            <states>
+                <textfilecontent54_state
+                    xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent"
+                    id="oval:my_test:ste:1" version="1">
+                    <subexpression>2024-05-29T12:00:00</subexpression>
+                </textfilecontent54_state>
+            </states>
+        </oval_definitions>
 
-</ds:extended-component>
-<ds:extended-component id="scap_org_ecomp_.noremoteaccess" timestamp="2024-05-29T12:00:00">
-  <oval_definitions xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5"
-    xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://oval.mitre.org/XMLSchema/oval-definitions-5 http://oval.mitre.org/language/download/schema/version5.10.1/ovaldefinition/complete/oval-definitions-schema.xsd">
-    <generator>
-      <oval:product_name>Custom</oval:product_name>
-      <oval:product_version>1.2.16</oval:product_version>
-      <oval:schema_version>5.11.1</oval:schema_version>
-      <oval:timestamp>2024-05-30T12:00:00</oval:timestamp>
-    </generator>
+    </ds:extended-component>
+    <ds:extended-component id="scap_org_ecomp_.noremoteaccess" timestamp="2024-05-29T12:00:00">
+        <oval_definitions xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5"
+            xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://oval.mitre.org/XMLSchema/oval-definitions-5 http://oval.mitre.org/language/download/schema/version5.10.1/ovaldefinition/complete/oval-definitions-schema.xsd">
+            <generator>
+                <oval:product_name>Custom</oval:product_name>
+                <oval:product_version>1.2.16</oval:product_version>
+                <oval:schema_version>5.11.1</oval:schema_version>
+                <oval:timestamp>2024-05-30T12:00:00</oval:timestamp>
+            </generator>
 
-    <definitions>
-      <definition id="oval:org.RemoteAccessServices:def:1" version="1" class="compliance">
-        <metadata>
-          <title>Check for installed Remote Access packages</title>
-          <description>Ensure that packages in the list are not installed on the system.</description>
-          <reference source="Custom" />
-          <affected family="unix">
-            <platform>Alpine Linux</platform>
-          </affected>
-        </metadata>
-        <criteria>
-          <criterion comment="Ensure packages starting with 'mypkg-' are installed"
-            test_ref="oval:org.RemoteAccessServices:tst:1" />
-        </criteria>
-      </definition>
-    </definitions>
+            <definitions>
+                <definition id="oval:org.RemoteAccessServices:def:1" version="1" class="compliance">
+                    <metadata>
+                        <title>Check for installed Remote Access packages</title>
+                        <description>Ensure that packages in the list are not installed on the
+                            system.</description>
+                        <reference source="Custom" />
+                        <affected family="unix">
+                            <platform>Alpine Linux</platform>
+                        </affected>
+                    </metadata>
+                    <criteria>
+                        <criterion comment="Ensure packages starting with 'mypkg-' are installed"
+                            test_ref="oval:org.RemoteAccessServices:tst:1" />
+                    </criteria>
+                </definition>
+            </definitions>
 
-    <tests>
-      <textfilecontent54_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent"
-        check="all" check_existence="none_exist"
-        comment="Check for installed packages starting with 'mypkg-' in /lib/apk/db/installed"
-        id="oval:org.RemoteAccessServices:tst:1" version="1">
-        <object object_ref="oval:org.RemoteAccessServices:obj:6" />
-        <state state_ref="oval:my_test:ste:1" />
-      </textfilecontent54_test>
-    </tests>
+            <tests>
+                <textfilecontent54_test
+                    xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent"
+                    check="all" check_existence="none_exist"
+                    comment="Check for installed packages starting with 'mypkg-' in /lib/apk/db/installed"
+                    id="oval:org.RemoteAccessServices:tst:1" version="1">
+                    <object object_ref="oval:org.RemoteAccessServices:obj:6" />
+                    <state state_ref="oval:my_test:ste:1" />
+                </textfilecontent54_test>
+            </tests>
 
-    <objects>
-      <textfilecontent54_object
-        xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent"
-        id="oval:org.RemoteAccessServices:obj:6" version="1">
-        <path>/lib/apk/db</path>
-        <filename>installed</filename>
-        <pattern operation="pattern match">
-          (openssh|openssh-server|openssh-client|openssh-sftp-server|dropbear|tigervnc|tigervnc-server|tigervnc-viewer|xrdp|xorgxrdp|vsftpd|proftpd|webmin|cockpit|cockpit-ws|cockpit-bridge|nfs-utils|samba|samba-server|samba-client|samba-common|rsh|telnet)-*</pattern>
-        <instance datatype="int">1</instance>
-      </textfilecontent54_object>
-    </objects>
+            <objects>
+                <textfilecontent54_object
+                    xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent"
+                    id="oval:org.RemoteAccessServices:obj:6" version="1">
+                    <path>/lib/apk/db</path>
+                    <filename>installed</filename>
+                    <pattern operation="pattern match">
+                        (openssh|openssh-server|openssh-client|openssh-sftp-server|dropbear|tigervnc|tigervnc-server|tigervnc-viewer|xrdp|xorgxrdp|vsftpd|proftpd|webmin|cockpit|cockpit-ws|cockpit-bridge|nfs-utils|samba|samba-server|samba-client|samba-common|rsh|telnet)-*</pattern>
+                    <instance datatype="int">1</instance>
+                </textfilecontent54_object>
+            </objects>
 
-    <states>
-      <textfilecontent54_state
-        xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent"
-        id="oval:my_test:ste:1" version="1">
-        <subexpression>20230201</subexpression>
-      </textfilecontent54_state>
-    </states>
-  </oval_definitions>
+            <states>
+                <textfilecontent54_state
+                    xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent"
+                    id="oval:my_test:ste:1" version="1">
+                    <subexpression>20230201</subexpression>
+                </textfilecontent54_state>
+            </states>
+        </oval_definitions>
 
-</ds:extended-component>
-<ds:extended-component id="scap_org_ecomp_.nopasswords" timestamp="2024-05-29T12:00:00">
-  <oval_definitions xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5"
-    xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://oval.mitre.org/XMLSchema/oval-definitions-5 http://oval.mitre.org/language/download/schema/version5.10.1/ovaldefinition/complete/oval-definitions-schema.xsd">
-    <generator>
-      <oval:product_name>OpenSCAP</oval:product_name>
-      <oval:product_version>1.2.16</oval:product_version>
-      <oval:schema_version>5.11.1</oval:schema_version>
-      <oval:timestamp>2024-05-29T12:00:00</oval:timestamp>
-    </generator>
+    </ds:extended-component>
+    <ds:extended-component id="scap_org_ecomp_.nopasswords" timestamp="2024-05-29T12:00:00">
+        <oval_definitions xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5"
+            xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://oval.mitre.org/XMLSchema/oval-definitions-5 http://oval.mitre.org/language/download/schema/version5.10.1/ovaldefinition/complete/oval-definitions-schema.xsd">
+            <generator>
+                <oval:product_name>OpenSCAP</oval:product_name>
+                <oval:product_version>1.2.16</oval:product_version>
+                <oval:schema_version>5.11.1</oval:schema_version>
+                <oval:timestamp>2024-05-29T12:00:00</oval:timestamp>
+            </generator>
 
-    <definitions>
-      <definition id="oval:org.example:def:3" version="1" class="compliance">
-        <metadata>
-          <title>Check for Hashed Passwords in /etc/shadow</title>
-          <description>Ensure there are passwords in the /etc/shadow file.</description>
-          <reference source="CIS" />
-          <affected family="unix">
-            <platform>Alpine Linux</platform>
-          </affected>
-        </metadata>
-        <criteria>
-          <criterion comment="Check for hashed passwords" test_ref="oval:org.example:tst:6" />
-        </criteria>
-      </definition>
-    </definitions>
+            <definitions>
+                <definition id="oval:org.example:def:3" version="1" class="compliance">
+                    <metadata>
+                        <title>Check for Hashed Passwords in /etc/shadow</title>
+                        <description>Ensure there are passwords in the /etc/shadow file.</description>
+                        <reference source="CIS" />
+                        <affected family="unix">
+                            <platform>Alpine Linux</platform>
+                        </affected>
+                    </metadata>
+                    <criteria>
+                        <criterion comment="Check for hashed passwords"
+                            test_ref="oval:org.example:tst:6" />
+                    </criteria>
+                </definition>
+            </definitions>
 
-    <tests>
-      <!-- Test to check for any lines after 'nobody' -->
-      <textfilecontent54_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent"
-        check="all" check_existence="none_exist"
-        comment="Check for unauthorized users after the 'nobody' line in /etc/shadow"
-        id="oval:org.example:tst:6" version="1">
-        <object object_ref="oval:org.example:obj:6" />
-      </textfilecontent54_test>
-    </tests>
+            <tests>
+                <!-- Test to check for any lines after 'nobody' -->
+                <textfilecontent54_test
+                    xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent"
+                    check="all" check_existence="none_exist"
+                    comment="Check for unauthorized users after the 'nobody' line in /etc/shadow"
+                    id="oval:org.example:tst:6" version="1">
+                    <object object_ref="oval:org.example:obj:6" />
+                </textfilecontent54_test>
+            </tests>
 
-    <objects>
-      <!-- Object to find any lines after 'nobody' -->
-      <textfilecontent54_object
-        xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent"
-        id="oval:org.example:obj:6" version="1">
-        <path>/etc</path>
-        <filename>shadow</filename>
-        <pattern operation="pattern match">^[^:]+:\$[^\n]*:</pattern>
-        <instance datatype="int">1</instance>
-      </textfilecontent54_object>
-    </objects>
+            <objects>
+                <!-- Object to find any lines after 'nobody' -->
+                <textfilecontent54_object
+                    xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent"
+                    id="oval:org.example:obj:6" version="1">
+                    <path>/etc</path>
+                    <filename>shadow</filename>
+                    <pattern operation="pattern match">^[^:]+:\$[^\n]*:</pattern>
+                    <instance datatype="int">1</instance>
+                </textfilecontent54_object>
+            </objects>
 
-    <states>
-      <!-- No specific states needed for this example -->
-      <textfilecontent54_state
-        xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent"
-        id="oval:my_test:ste:1" version="1">
-        <subexpression>20230201</subexpression>
-      </textfilecontent54_state>
-    </states>
-  </oval_definitions>
-</ds:extended-component>
-<ds:extended-component id="scap_org_ecomp_.varlog" timestamp="2024-05-29T12:00:00">
-  <oval_definitions xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5"
-    xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://oval.mitre.org/XMLSchema/oval-definitions-5 http://oval.mitre.org/language/download/schema/version5.10.1/ovaldefinition/complete/oval-definitions-schema.xsd">
-    <generator>
-      <oval:product_name>OpenSCAP</oval:product_name>
-      <oval:product_version>1.2.16</oval:product_version>
-      <oval:schema_version>5.11.1</oval:schema_version>
-      <oval:timestamp>2024-05-29T12:00:00</oval:timestamp>
-    </generator>
+            <states>
+                <!-- No specific states needed for this example -->
+                <textfilecontent54_state
+                    xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent"
+                    id="oval:my_test:ste:1" version="1">
+                    <subexpression>20230201</subexpression>
+                </textfilecontent54_state>
+            </states>
+        </oval_definitions>
+    </ds:extended-component>
+    <ds:extended-component id="scap_org_ecomp_.varlog" timestamp="2024-05-29T12:00:00">
+        <oval_definitions xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5"
+            xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://oval.mitre.org/XMLSchema/oval-definitions-5 http://oval.mitre.org/language/download/schema/version5.10.1/ovaldefinition/complete/oval-definitions-schema.xsd">
+            <generator>
+                <oval:product_name>OpenSCAP</oval:product_name>
+                <oval:product_version>1.2.16</oval:product_version>
+                <oval:schema_version>5.11.1</oval:schema_version>
+                <oval:timestamp>2024-05-29T12:00:00</oval:timestamp>
+            </generator>
 
-    <definitions>
+            <definitions>
 
-      <definition id="oval:org.varlog:def:2" version="1" class="compliance">
-        <metadata>
-          <title>Check Var/Log Permissions</title>
-          <description>Ensure /var/log has root:root permissions.</description>
-          <reference source="CIS" />
-          <affected family="unix">
-            <platform>Debian GNU/Linux 10</platform>
-          </affected>
-        </metadata>
-        <criteria>
-          <criterion comment="All files in /usr/lib have root:root permissions"
-            test_ref="oval:org.varlog:tst:5" />
-        </criteria>
-      </definition>
-    </definitions>
+                <definition id="oval:org.varlog:def:2" version="1" class="compliance">
+                    <metadata>
+                        <title>Check Var/Log Permissions</title>
+                        <description>Ensure /var/log has root:root permissions.</description>
+                        <reference source="CIS" />
+                        <affected family="unix">
+                            <platform>Debian GNU/Linux 10</platform>
+                        </affected>
+                    </metadata>
+                    <criteria>
+                        <criterion comment="All files in /usr/lib have root:root permissions"
+                            test_ref="oval:org.varlog:tst:5" />
+                    </criteria>
+                </definition>
+            </definitions>
 
-    <tests>
-      <unix:file_test id="oval:org.varlog:tst:5" version="1" check="all"
-        check_existence="at_least_one_exists" comment="Check existence of /var/log directory"
-        xmlns:unix="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix">
-        <unix:object object_ref="oval:org.varlog:obj:5" />
+            <tests>
+                <unix:file_test id="oval:org.varlog:tst:5" version="1" check="all"
+                    check_existence="at_least_one_exists"
+                    comment="Check existence of /var/log directory"
+                    xmlns:unix="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix">
+                    <unix:object object_ref="oval:org.varlog:obj:5" />
 
-        <unix:state state_ref="oval:org.varlog:ste:5" />
-      </unix:file_test>
-    </tests>
+                    <unix:state state_ref="oval:org.varlog:ste:5" />
+                </unix:file_test>
+            </tests>
 
-    <objects>
+            <objects>
 
-      <unix:file_object id="oval:org.varlog:obj:5" version="1"
-        xmlns:unix="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix">
-        <unix:path>/var/log</unix:path>
-        <unix:filename xsi:nil="true" />
-      </unix:file_object>
+                <unix:file_object id="oval:org.varlog:obj:5" version="1"
+                    xmlns:unix="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix">
+                    <unix:path>/var/log</unix:path>
+                    <unix:filename xsi:nil="true" />
+                </unix:file_object>
 
-    </objects>
+            </objects>
 
-    <states>
-      <unix:file_state id="oval:org.varlog:ste:5" version="1"
-        xmlns:unix="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix">
-        <unix:group_id datatype="int">0</unix:group_id>
-        <unix:user_id datatype="int">0</unix:user_id>
-      </unix:file_state>
+            <states>
+                <unix:file_state id="oval:org.varlog:ste:5" version="1"
+                    xmlns:unix="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix">
+                    <unix:group_id datatype="int">0</unix:group_id>
+                    <unix:user_id datatype="int">0</unix:user_id>
+                </unix:file_state>
 
-    </states>
-  </oval_definitions>
-</ds:extended-component>
+            </states>
+        </oval_definitions>
+    </ds:extended-component>
 </ds:data-stream-collection>

--- a/gpos/xml/scap/ssg/content/ssg-chainguard-gpos-ds.xml
+++ b/gpos/xml/scap/ssg/content/ssg-chainguard-gpos-ds.xml
@@ -6516,8 +6516,7 @@
                     id="oval:org.OpenSsl:obj:3" version="1">
                     <path>/lib/apk/db</path>
                     <filename>installed</filename>
-                    <pattern operation="pattern match">
-                        ^P:openssl-config-fipshardened(-\d+\.\d+\.\d+)?$</pattern>
+                    <pattern operation="pattern match">^P:openssl-config-fipshardened(-\d+\.\d+\.\d+)?$</pattern>
                     <instance datatype="int">1</instance>
                 </textfilecontent54_object>
 


### PR DESCRIPTION

**New Rules Added:**
| Rule ID                                           | What it asks for                                | Applies inside a container | Notes                                                                                                                 |
|--------------------------------------------------|--------------------------------------------------|-----------------------------|------------------------------------------------------------------------------------------------------------------------|
| SRG-OS-000590-GPOS-00110 / V-263650              | Disable accounts no longer linked to a user     | ✅ Yes                      |  Test with No Users Check |
| SRG-OS-000690-GPOS-00140 / V-263651              | Prohibit unauthorized hardware components       | ❌ No                       | N/A, No wifi or USB rationale |
| SRG-OS-000705-GPOS-00150 / V-263652              | MFA for privileged/non-privileged access        | ✅ Yes                      | Test with No Remote Access check |
| SRG-OS-000710-GPOS-00160 / V-263653              | Check passwords against bad-password list       | ❌ No                       |  N/A, No New Password Rationale |
| SRG-OS-000720-GPOS-00170 / V-263654              | Force password change after account recovery    | ❌ No                       | NA, No New Password Rationale |
| SRG-OS-000725-GPOS-00180 / V-263655              | Allow long passphrases                          | ❌ No                       | If your NA, No New Password Rationale |
| SRG-OS-000730-GPOS-00190 / V-263656              | Help users pick strong passwords                | ❌ No                       | NA, No New Password Rationale |
| SRG-OS-000745-GPOS-00210 / V-263657              | Accept only NIST-compliant external credentials | ❌ No                       | NA, Responsibility Of Host |
| SRG-OS-000755-GPOS-00220 / V-263658              | Monitor elevated tool usage                     | ❌ No                       | Enable NA, Auditing Rationale |
| SRG-OS-000775-GPOS-00230 / V-263659              | Only approved trust anchors in trust store      | ✅ Yes                      | I encountered limitations using apk audit to verify CA bundle integrity during OpenSCAP image-based scans due to lack of persistent audit metadata in ephemeral scan containers. Instead, I've adopted a SHA256 hash-based check of /etc/ssl/certs/ca-certificates.crt and plan to integrate with octo-bot to automate updates. |
| SRG-OS-000780-GPOS-00240 / V-263660              | Protect crypto key storage                      | ❌ No                       | Ensure N/A, Host File System rationale |
| SRG-OS-000785-GPOS-00250 / V-263661              | Synchronize clocks                              | ❌ No                       | Confirm N/A, Time rationale |

**Rules changed:**
The following rules were updated for grammatical or metadata (CCI) reasons only, no change in what’s evaluated:

- V-203644 (SRG-OS-000109-GPOS-00056)
- V-203632 (SRG-OS-000076-GPOS-00044)
- V-203720 (SRG-OS-000366-GPOS-00153)
- V-203711 (SRG-OS-000355-GPOS-00143)
- V-203625 (SRG-OS-000069-GPOS-00037)
- V-203691 (SRG-OS-000304-GPOS-00121)
- V-203626 (SRG-OS-000070-GPOS-00038)
- V-203628 (SRG-OS-000072-GPOS-00040)
- V-203643 (SRG-OS-000108-GPOS-00055)
- V-203727 (SRG-OS-000375-GPOS-00160)
- V-203725 (SRG-OS-000373-GPOS-00158)
- V-203724 (SRG-OS-000373-GPOS-00157)
- V-203642 (SRG-OS-000107-GPOS-00054)
- V-203646 (SRG-OS-000113-GPOS-00058)
- V-203723 (SRG-OS-000373-GPOS-00156)

**Rules Removed**

- V-203612 — SRG-OS-000047-GPOS-00023
- V-203633 — SRG-OS-000077-GPOS-00045
- V-203654 — SRG-OS-000126-GPOS-00066
- V-203662 — SRG-OS-000191-GPOS-00080
- V-203726 — SRG-OS-000374-GPOS-00159
- V-203732 — SRG-OS-000380-GPOS-00165