### PR TITLE
stig: tighten package check for RemoteAccessServices

### DIFF
--- a/gpos/xml/scap/ssg/content/ssg-chainguard-gpos-ds.xml
+++ b/gpos/xml/scap/ssg/content/ssg-chainguard-gpos-ds.xml
@@ -6786,7 +6786,7 @@
                     id="oval:org.RemoteAccessServices:obj:6" version="1">
                     <path>/lib/apk/db</path>
                     <filename>installed</filename>
-                    <pattern operation="pattern match">(openssh|openssh-server|openssh-client|openssh-sftp-server|dropbear|tigervnc|tigervnc-server|tigervnc-viewer|xrdp|xorgxrdp|vsftpd|proftpd|webmin|cockpit|cockpit-ws|cockpit-bridge|nfs-utils|samba|samba-server|samba-client|samba-common|rsh|telnet)-*</pattern>
+                    <pattern operation="pattern match">^P:(openssh|openssh-server|openssh-client|openssh-sftp-server|dropbear|tigervnc|tigervnc-server|tigervnc-viewer|xrdp|xorgxrdp|vsftpd|proftpd|webmin|cockpit|cockpit-ws|cockpit-bridge|nfs-utils|samba|samba-server|samba-client|samba-common|rsh|telnet)-*</pattern>
                     <instance datatype="int">1</instance>
                 </textfilecontent54_object>
             </objects>


### PR DESCRIPTION
The RemoteAccessServices check is intended to look for a set of installed services / packages; however the pattern match rule did not scope it's pattern to only match package names, so it would catch some false positives.

This issue was masked by a prior bug in the pattern match that was fixed in abb2237 ("changed hash script check into oval check and updated scap schema") where it would never match anything because of the newline in pattern -- that bug has been present since the initial publication of the stig.

Ref: https://github.com/chainguard-dev/prodsec/issues/220