### PR TITLE
stig: reflow text

### DIFF
--- a/gpos/xml/scap/ssg/content/ssg-chainguard-gpos-ds.xml
+++ b/gpos/xml/scap/ssg/content/ssg-chainguard-gpos-ds.xml
@@ -173,20 +173,16 @@
                         components.</ns0:title>
                     <ns0:description xml:lang="en">Hardware components provide the foundation for
                         organizational systems and the platform for the execution of authorized
-                        software
-                        programs. Managing the inventory of hardware components and controlling
-                        which
-                        hardware components are permitted to be installed or connected to
-                        organizational
-                        systems is essential to provide adequate
+                        software programs. Managing the inventory of hardware components and
+                        controlling which hardware components are permitted to be installed or
+                        connected to organizational systems is essential to provide adequate
                         security.</ns0:description>
                     <ns0:rationale>Linux containers do not automatically inherit access to
-                        underlying hardware such as USB and
-                        WiFi adapters on the hosts where they operate. If these connections exist,
-                        they must be specifically configured when deploying the image on a host. A
-                        host configured to meet STIG requirements will disable unused USB
-                        connections and implement properly configured WiFi interfaces (if necessary
-                        for the operation of the service).
+                        underlying hardware such as USB and WiFi adapters on the hosts where they
+                        operate. If these connections exist, they must be specifically configured
+                        when deploying the image on a host. A host configured to meet STIG
+                        requirements will disable unused USB connections and implement properly
+                        configured WiFi interfaces (if necessary for the operation of the service).
 
                         For more information on inherited controls for containers see the DISA
                         Container Hardening Process Guide.</ns0:rationale>
@@ -194,47 +190,30 @@
                 </ns0:Rule>
                 <ns0:Rule id="xccdf_._rule_V_263653" selected="true" severity="medium">
                     <ns0:title xml:lang="en">The operating system must, for password-based
-                        authentication, verify
-                        when users
-                        create or update passwords the passwords are not found on the list of
-                        commonly-used,
-                        expected, or compromised passwords in IA-5 (1) (a).</ns0:title>
-                    <ns0:description xml:lang="en">Password-based authentication applies to
-                        passwords
-                        regardless of whether they are used in single-factor or multifactor
-                        authentication.
-                        Long passwords or passphrases are preferable over shorter passwords.
-                        Enforced
-                        composition rules provide marginal security benefits while decreasing
-                        usability.
-                        However, organizations may choose to establish certain rules for password
-                        generation
-                        (e.g., minimum character length for long passwords) under certain
-                        circumstances and
-                        can enforce this requirement in IA-5(1)(h). Account recovery can occur, for
-                        example,
-                        in situations when a password is forgotten. Cryptographically protected
-                        passwords
-                        include salted one-way cryptographic hashes of passwords. The list of
-                        commonly used,
-                        compromised, or expected passwords includes passwords obtained from previous
-                        breach
-                        corpuses, dictionary words, and repetitive or sequential characters. The
-                        list
-                        includes context-specific words, such as the name of the service, username,
-                        and
-                        derivatives
-                        thereof.</ns0:description>
+                        authentication, verify when users create or update passwords the
+                        passwords are not found on the list of commonly-used, expected, or
+                        compromised passwords in IA-5 (1) (a).</ns0:title>
+                    <ns0:description xml:lang="en">Password-based authentication applies
+                        to passwords regardless of whether they are used in single-factor or
+                        multifactor authentication. Long passwords or passphrases are preferable
+                        over shorter passwords. Enforced composition rules provide marginal
+                        security benefits while decreasing usability. However, organizations may
+                        choose to establish certain rules for password generation (e.g., minimum
+                        character length for long passwords) under certain circumstances and can
+                        enforce this requirement in IA-5(1)(h). Account recovery can occur, for
+                        example, in situations when a password is forgotten. Cryptographically
+                        protected passwords include salted one-way cryptographic hashes
+                        of passwords. The list of commonly used, compromised, or expected
+                        passwords includes passwords obtained from previous breach corpuses,
+                        dictionary words, and repetitive or sequential characters. The list
+                        includes context-specific words, such as the name of the service,
+                        username, and derivatives thereof.</ns0:description>
                     <ns0:rationale>The container image is built with no local user accounts other
-                        than a locked
-                        root. All interactive or programmatic access to the workload is handled by
-                        the
-                        container-orchestration platform, which enforces its own credential hygiene
-                        and MFA
-                        controls. The OS inside the container never receives, stores, or validates
-                        passwords and no
-                        password database exists against which to apply bad-password screening,
-                        forced post-recovery
+                        than a locked root. All interactive or programmatic access to the workload
+                        is handled by the container-orchestration platform, which enforces its
+                        own credential hygiene and MFA controls. The OS inside the container
+                        never receives, stores, or validates passwords and no password database
+                        exists against which to apply bad-password screening, forced post-recovery
                         changes, passphrase-length rules, or password-generation aids.
 
                         For more information on inherited controls for containers see the DISA
@@ -243,45 +222,29 @@
                 </ns0:Rule>
                 <ns0:Rule id="xccdf_._rule_V_263654" selected="true" severity="medium">
                     <ns0:title xml:lang="en">The operating system must for password-based
-                        authentication, require
-                        immediate
-                        selection of a new password upon account recovery.</ns0:title>
-                    <ns0:description xml:lang="en">Password-based authentication applies to
-                        passwords
-                        regardless of whether they are used in single-factor or multifactor
-                        authentication.
-                        Long passwords or passphrases are preferable over shorter passwords.
-                        Enforced
-                        composition rules provide marginal security benefits while decreasing
-                        usability.
-                        However, organizations may choose to establish certain rules for
-                        password generation
-                        (e.g., minimum character length for long passwords) under certain
-                        circumstances and
-                        can enforce this requirement in IA-5(1)(h). Account recovery can occur,
-                        for example,
-                        in situations when a password is forgotten. Cryptographically protected
-                        passwords
-                        include salted one-way cryptographic hashes of passwords. The list of
-                        commonly used,
-                        compromised, or expected passwords includes passwords obtained from
-                        previous breach
-                        corpuses, dictionary words, and repetitive or sequential characters. The
-                        list
+                        authentication, require immediate selection of a new password upon
+                        account recovery.</ns0:title>
+                    <ns0:description xml:lang="en">Password-based authentication applies
+                        to passwords regardless of whether they are used in single-factor or
+                        multifactor authentication. Long passwords or passphrases are preferable
+                        over shorter passwords. Enforced composition rules provide marginal
+                        security benefits while decreasing usability. However, organizations may
+                        choose to establish certain rules for password generation (e.g., minimum
+                        character length for long passwords) under certain circumstances and can
+                        enforce this requirement in IA-5(1)(h). Account recovery can occur, for
+                        example, in situations when a password is forgotten. Cryptographically
+                        protected passwords include salted one-way cryptographic hashes
+                        of passwords. The list of commonly used, compromised, or expected
+                        passwords includes passwords obtained from previous breach corpuses,
+                        dictionary words, and repetitive or sequential characters. The list
                         includes context-specific words, such as the name of the service,
-                        username, and
-                        derivatives
-                        thereof.</ns0:description>
-                    <ns0:rationale>The container image is built with no local user accounts
-                        other than a locked
-                        root. All interactive or programmatic access to the workload is handled
-                        by the
-                        container-orchestration platform, which enforces its own credential
-                        hygiene and MFA
-                        controls. The OS inside the container never receives, stores, or
-                        validates passwords and no
-                        password database exists against which to apply bad-password screening,
-                        forced post-recovery
+                        username, and derivatives thereof.</ns0:description>
+                    <ns0:rationale>The container image is built with no local user accounts other
+                        than a locked root. All interactive or programmatic access to the workload
+                        is handled by the container-orchestration platform, which enforces its
+                        own credential hygiene and MFA controls. The OS inside the container
+                        never receives, stores, or validates passwords and no password database
+                        exists against which to apply bad-password screening, forced post-recovery
                         changes, passphrase-length rules, or password-generation aids.
 
                         For more information on inherited controls for containers see the DISA
@@ -290,46 +253,29 @@
                 </ns0:Rule>
                 <ns0:Rule id="xccdf_._rule_V_263655" selected="true" severity="medium">
                     <ns0:title xml:lang="en">The operating system must for password-based
-                        authentication, allow user
-                        selection
-                        of long passwords and passphrases, including spaces and all printable
-                        characters.</ns0:title>
-                    <ns0:description xml:lang="en">Password-based authentication applies to
-                        passwords
-                        regardless of whether they are used in single-factor or multifactor
-                        authentication.
-                        Long passwords or passphrases are preferable over shorter passwords.
-                        Enforced
-                        composition rules provide marginal security benefits while decreasing
-                        usability.
-                        However, organizations may choose to establish certain rules for password
-                        generation
-                        (e.g., minimum character length for long passwords) under certain
-                        circumstances and
-                        can enforce this requirement in IA-5(1)(h). Account recovery can occur, for
-                        example,
-                        in situations when a password is forgotten. Cryptographically protected
-                        passwords
-                        include salted one-way cryptographic hashes of passwords. The list of
-                        commonly used,
-                        compromised, or expected passwords includes passwords obtained from previous
-                        breach
-                        corpuses, dictionary words, and repetitive or sequential characters. The
-                        list
-                        includes context-specific words, such as the name of the service, username,
-                        and
-                        derivatives
-                        thereof.</ns0:description>
+                        authentication, allow user selection of long passwords and passphrases,
+                        including spaces and all printable characters.</ns0:title>
+                    <ns0:description xml:lang="en">Password-based authentication applies
+                        to passwords regardless of whether they are used in single-factor or
+                        multifactor authentication. Long passwords or passphrases are preferable
+                        over shorter passwords. Enforced composition rules provide marginal
+                        security benefits while decreasing usability. However, organizations may
+                        choose to establish certain rules for password generation (e.g., minimum
+                        character length for long passwords) under certain circumstances and can
+                        enforce this requirement in IA-5(1)(h). Account recovery can occur, for
+                        example, in situations when a password is forgotten. Cryptographically
+                        protected passwords include salted one-way cryptographic hashes
+                        of passwords. The list of commonly used, compromised, or expected
+                        passwords includes passwords obtained from previous breach corpuses,
+                        dictionary words, and repetitive or sequential characters. The list
+                        includes context-specific words, such as the name of the service,
+                        username, and derivatives thereof.</ns0:description>
                     <ns0:rationale>The container image is built with no local user accounts other
-                        than a locked
-                        root. All interactive or programmatic access to the workload is handled by
-                        the
-                        container-orchestration platform, which enforces its own credential hygiene
-                        and MFA
-                        controls. The OS inside the container never receives, stores, or validates
-                        passwords and no
-                        password database exists against which to apply bad-password screening,
-                        forced post-recovery
+                        than a locked root. All interactive or programmatic access to the workload
+                        is handled by the container-orchestration platform, which enforces its
+                        own credential hygiene and MFA controls. The OS inside the container
+                        never receives, stores, or validates passwords and no password database
+                        exists against which to apply bad-password screening, forced post-recovery
                         changes, passphrase-length rules, or password-generation aids.
 
                         For more information on inherited controls for containers see the DISA
@@ -338,45 +284,29 @@
                 </ns0:Rule>
                 <ns0:Rule id="xccdf_._rule_V_263656" selected="true" severity="medium">
                     <ns0:title xml:lang="en">The operating system must, for password-based
-                        authentication, employ
-                        automated
-                        tools to assist the user in selecting strong password authenticators.</ns0:title>
-                    <ns0:description xml:lang="en">Password-based authentication applies to
-                        passwords
-                        regardless of whether they are used in single-factor or multifactor
-                        authentication.
-                        Long passwords or passphrases are preferable over shorter passwords.
-                        Enforced
-                        composition rules provide marginal security benefits while decreasing
-                        usability.
-                        However, organizations may choose to establish certain rules for password
-                        generation
-                        (e.g., minimum character length for long passwords) under certain
-                        circumstances and
-                        can enforce this requirement in IA-5(1)(h). Account recovery can occur, for
-                        example,
-                        in situations when a password is forgotten. Cryptographically protected
-                        passwords
-                        include salted one-way cryptographic hashes of passwords. The list of
-                        commonly used,
-                        compromised, or expected passwords includes passwords obtained from previous
-                        breach
-                        corpuses, dictionary words, and repetitive or sequential characters. The
-                        list
-                        includes context-specific words, such as the name of the service, username,
-                        and
-                        derivatives
-                        thereof.</ns0:description>
+                        authentication, employ automated tools to assist the user in selecting
+                        strong password authenticators.</ns0:title>
+                    <ns0:description xml:lang="en">Password-based authentication applies
+                        to passwords regardless of whether they are used in single-factor or
+                        multifactor authentication. Long passwords or passphrases are preferable
+                        over shorter passwords. Enforced composition rules provide marginal
+                        security benefits while decreasing usability. However, organizations may
+                        choose to establish certain rules for password generation (e.g., minimum
+                        character length for long passwords) under certain circumstances and can
+                        enforce this requirement in IA-5(1)(h). Account recovery can occur, for
+                        example, in situations when a password is forgotten. Cryptographically
+                        protected passwords include salted one-way cryptographic hashes
+                        of passwords. The list of commonly used, compromised, or expected
+                        passwords includes passwords obtained from previous breach corpuses,
+                        dictionary words, and repetitive or sequential characters. The list
+                        includes context-specific words, such as the name of the service,
+                        username, and derivatives thereof.</ns0:description>
                     <ns0:rationale>The container image is built with no local user accounts other
-                        than a locked
-                        root. All interactive or programmatic access to the workload is handled by
-                        the
-                        container-orchestration platform, which enforces its own credential hygiene
-                        and MFA
-                        controls. The OS inside the container never receives, stores, or validates
-                        passwords and no
-                        password database exists against which to apply bad-password screening,
-                        forced post-recovery
+                        than a locked root. All interactive or programmatic access to the workload
+                        is handled by the container-orchestration platform, which enforces its
+                        own credential hygiene and MFA controls. The OS inside the container
+                        never receives, stores, or validates passwords and no password database
+                        exists against which to apply bad-password screening, forced post-recovery
                         changes, passphrase-length rules, or password-generation aids.
 
                         For more information on inherited controls for containers see the DISA
@@ -385,31 +315,23 @@
                 </ns0:Rule>
                 <ns0:Rule id="xccdf_._rule_V_263657" selected="true" severity="medium">
                     <ns0:title xml:lang="en">The operating system must accept only external
-                        credentials that are
-                        NIST-compliant</ns0:title>
+                        credentials that are NIST-compliant</ns0:title>
                     <ns0:description xml:lang="en">Acceptance of only NIST-compliant external
-                        authenticators applies to organizational systems that are accessible to the
-                        public
-                        (e.g., public-facing websites). External authenticators are issued by
-                        nonfederal
-                        government entities and are compliant with [SP 800-63B]. Approved external
-                        authenticators meet or exceed the minimum federal government-wide technical,
-                        security, privacy, and organizational maturity requirements. Meeting or
-                        exceeding
-                        federal requirements allows federal government relying parties to trust
-                        external
-                        authenticators in connection with an authentication transaction at a
-                        specified
-                        authenticator assurance
-                        level.</ns0:description>
-                    <ns0:rationale>Linux containers rely on the host operating system to manage and
-                        enforce
-                        authentication mechanisms, including the validation of external credentials.
-                        Because
-                        containers delegate user authentication and identity management to the host
-                        environment, it is the host operating system that is ultimately responsible
-                        for ensuring
-                        that only NIST-compliant external authenticators are accepted.
+                        authenticators applies to organizational systems that are accessible
+                        to the public (e.g., public-facing websites). External authenticators
+                        are issued by nonfederal government entities and are compliant with [SP
+                        800-63B]. Approved external authenticators meet or exceed the minimum
+                        federal government-wide technical, security, privacy, and organizational
+                        maturity requirements. Meeting or exceeding federal requirements allows
+                        federal government relying parties to trust external authenticators in
+                        connection with an authentication transaction at a specified authenticator
+                        assurance level.</ns0:description>
+                    <ns0:rationale>Linux containers rely on the host operating system to manage
+                        and enforce authentication mechanisms, including the validation of
+                        external credentials. Because containers delegate user authentication
+                        and identity management to the host environment, it is the host operating
+                        system that is ultimately responsible for ensuring that only NIST-compliant
+                        external authenticators are accepted.
 
                         For more information on inherited controls for containers, see the DISA
                         Container Hardening
@@ -418,14 +340,10 @@
                 </ns0:Rule>
                 <ns0:Rule id="xccdf_._rule_V_263658" selected="true" severity="medium">
                     <ns0:title xml:lang="en">The operating system must monitor the use of
-                        maintenance tools that
-                        execute with
-                        increased privilege</ns0:title>
-                    <ns0:description xml:lang="en">Maintenance tools that execute with increased
-                        system
-                        privilege can result in unauthorized access to organizational information
-                        and assets
-                        that would otherwise be
+                        maintenance tools that execute with increased privilege</ns0:title>
+                    <ns0:description xml:lang="en">Maintenance tools that execute with
+                        increased system privilege can result in unauthorized access to
+                        organizational information and assets that would otherwise be
                         inaccessible.</ns0:description>
                     <ns0:rationale>Auditing capabilities for Linux containers are implemented by the
                         underlying host's audit configuration. In Linux, the auditing program auditd
@@ -450,22 +368,17 @@
                     <ns0:platform idref="cpe:/o:notapplicable" />
                 </ns0:Rule>
                 <ns0:Rule id="xccdf_._rule_V_263660" selected="true" severity="medium">
-                    <ns0:title xml:lang="en">The operating system must provide protected storage for
-                        cryptographic
-                        keys with
-                        organization-defined safeguards and/or hardware protected key store.</ns0:title>
-                    <ns0:description xml:lang="en">A Trusted Platform Module (TPM) is an example of
-                        a
-                        hardware-protected data store that can be used to protect cryptographic
-                        keys.</ns0:description>
-                    <ns0:rationale>Linux containers utilize the host filesystem for storage of their
-                        files and
-                        configuration. Protecting data at rest inside containers from unauthorized
-                        access or
-                        modification must be configured at the host operating system such as
-                        encrypted virtual
-                        filesystems. The host filesystem is also responsible for the size,
-                        utilization, and capacity
+                    <ns0:title xml:lang="en">The operating system must provide protected
+                        storage for cryptographic keys with organization-defined safeguards
+                        and/or hardware protected key store.</ns0:title>
+                    <ns0:description xml:lang="en">A Trusted Platform Module (TPM) is an
+                        example of a hardware-protected data store that can be used to protect
+                        cryptographic keys.</ns0:description>
+                    <ns0:rationale>Linux containers utilize the host filesystem for storage of
+                        their files and configuration. Protecting data at rest inside containers
+                        from unauthorized access or modification must be configured at the
+                        host operating system such as encrypted virtual filesystems. The host
+                        filesystem is also responsible for the size, utilization, and capacity
                         of the physical disks that are used by containers running on that host.
 
                         For more information on inherited controls for containers see the DISA
@@ -474,46 +387,30 @@
                 </ns0:Rule>
                 <ns0:Rule id="xccdf_._rule_V_263661" selected="true" severity="medium">
                     <ns0:title xml:lang="en">The operating system must synchronize system clocks
-                        within and between
-                        systems or
-                        system components.</ns0:title>
+                        within and between systems or system components.</ns0:title>
                     <ns0:description xml:lang="en">Time synchronization of system clocks is
-                        essential
-                        for the correct execution of many system services, including identification
-                        and
-                        authentication processes that involve certificates and time-of-day
-                        restrictions as
-                        part of access control. Denial of service or failure to deny expired
-                        credentials may
-                        result without properly synchronized clocks within and between systems and
-                        system
-                        components. Time is commonly expressed in Coordinated Universal Time (UTC),
-                        a modern
-                        continuation of Greenwich Mean Time (GMT), or local time with an offset from
-                        UTC.
-                        The granularity of time measurements refers to the degree of synchronization
-                        between
-                        system clocks and reference clocks, such as clocks synchronizing within
-                        hundreds of
-                        milliseconds or tens of milliseconds. Organizations may define different
-                        time
-                        granularities for system components. Time service can be critical to other
-                        security
-                        capabilities—such as access control and identification and
-                        authentication—depending
-                        on the nature of the mechanisms used to support the
-                        capabilities.</ns0:description>
-                    <ns0:rationale>Linux containers inherit the system time from the underlying host
-                        - a separate
-                        time service is not operated within the container. The host owner is
-                        responsible for
-                        configuring the host's time service to generate the timestamp used by its
-                        auditing system,
-                        perform periodic synchronization, and ensure that only authorized time
-                        servers are used as
-                        the authoritative source. Time synchronization of the host clock is
-                        automatically reflected
-                        in the time used by the container.
+                        essential for the correct execution of many system services, including
+                        identification and authentication processes that involve certificates
+                        and time-of-day restrictions as part of access control. Denial of
+                        service or failure to deny expired credentials may result without
+                        properly synchronized clocks within and between systems and system
+                        components. Time is commonly expressed in Coordinated Universal Time
+                        (UTC), a modern continuation of Greenwich Mean Time (GMT), or local time
+                        with an offset from UTC. The granularity of time measurements refers
+                        to the degree of synchronization between system clocks and reference
+                        clocks, such as clocks synchronizing within hundreds of milliseconds
+                        or tens of milliseconds. Organizations may define different time
+                        granularities for system components. Time service can be critical to
+                        other security capabilities—such as access control and identification
+                        and authentication—depending on the nature of the mechanisms used to
+                        support the capabilities.</ns0:description>
+                    <ns0:rationale>Linux containers inherit the system time from the underlying
+                        host - a separate time service is not operated within the container. The
+                        host owner is responsible for configuring the host's time service to
+                        generate the timestamp used by its auditing system, perform periodic
+                        synchronization, and ensure that only authorized time servers are used
+                        as the authoritative source. Time synchronization of the host clock is
+                        automatically reflected in the time used by the container.
 
                         For more information on inherited controls for containers see the DISA
                         Container Hardening Process Guide.</ns0:rationale>
@@ -1792,34 +1689,25 @@
                 </ns0:Rule>
                 <ns0:Rule id="xccdf_._rule_V_203691" selected="true" severity="medium">
                     <ns0:title xml:lang="en">The operating system must notify system administrators
-                        (SAs) and information
-                        system security officers (ISSOs) of account enabling actions.</ns0:title>
-                    <ns0:description xml:lang="en">Once an attacker establishes access to a system,
-                        the
-                        attacker often attempts to create a persistent method of reestablishing
-                        access. One
-                        way to accomplish this is for the attacker to enable an existing disabled
-                        account.
-                        Sending notification of account enabling actions to the SA and ISSO is one
-                        method
-                        for mitigating this risk. Such a capability greatly reduces the risk that
-                        operating
-                        system accessibility will be negatively affected for extended periods of
-                        time and
-                        also provides logging that can be used for forensic purposes.
+                        (SAs) and information system security officers (ISSOs) of account
+                        enabling actions.</ns0:title>
+                    <ns0:description xml:lang="en">Once an attacker establishes access to a
+                        system, the attacker often attempts to create a persistent method of
+                        reestablishing access. One way to accomplish this is for the attacker to
+                        enable an existing disabled account. Sending notification of account
+                        enabling actions to the SA and ISSO is one method for mitigating this
+                        risk. Such a capability greatly reduces the risk that operating system
+                        accessibility will be negatively affected for extended periods of time
+                        and also provides logging that can be used for forensic purposes.
 
                         To detect and respond to events that affect user accessibility and
-                        application
-                        processing, operating systems must audit account enabling actions and, as
-                        required,
-                        notify the appropriate individuals so they can investigate the event.
+                        application processing, operating systems must audit account enabling
+                        actions and, as required, notify the appropriate individuals so they
+                        can investigate the event.
 
                         To address access requirements, many operating systems can be integrated
-                        with
-                        enterprise-level authentication/access/auditing mechanisms that meet or
-                        exceed
-                        access control policy
-                        requirements.</ns0:description>
+                        with enterprise-level authentication/access/auditing mechanisms that
+                        meet or exceed access control policy requirements.</ns0:description>
                     <ns0:rationale>Auditing capabilities for Linux containers are implemented by the
                         underlying host's audit configuration. In Linux, the auditing program auditd
                         leverages multiple functions in the running kernel through the Linux
@@ -4447,42 +4335,32 @@
                 </ns0:Rule>
                 <ns0:Rule id="xccdf_._rule_V_203727" selected="true" severity="medium">
                     <ns0:title xml:lang="en">The operating system must implement multifactor
-                        authentication for remote access
-                        to privileged accounts in such a way that one of the factors is provided by
-                        a device
-                        separate from the system gaining access.</ns0:title>
-                    <ns0:description xml:lang="en">Using an authentication device, such as a common
-                        access card (CAC) or token that is separate from the information system,
-                        ensures
-                        that even if the information system is compromised, that compromise will not
-                        affect
-                        credentials stored on the authentication device.
+                        authentication for remote access to privileged accounts in such a way
+                        that one of the factors is provided by a device separate from the system
+                        gaining access.</ns0:title>
+                    <ns0:description xml:lang="en">Using an authentication device, such as a
+                        common access card (CAC) or token that is separate from the information
+                        system, ensures that even if the information system is compromised, that
+                        compromise will not affect credentials stored on the authentication device.
 
-                        Multifactor solutions that require devices separate from information systems
-                        gaining
-                        access include, for example, hardware tokens providing time-based or
-                        challenge-response authenticators and smart cards such as the U.S.
-                        Government
-                        Personal Identity Verification (PIV) card and the DOD CAC.
+                        Multifactor solutions that require devices separate from information
+                        systems gaining access include, for example, hardware tokens providing
+                        time-based or challenge-response authenticators and smart cards such
+                        as the U.S. Government Personal Identity Verification (PIV) card and
+                        the DOD CAC.
 
                         A privileged account is defined as an information system account with
-                        authorizations
-                        of a privileged user.
+                        authorizations of a privileged user.
 
                         Remote access is access to DOD nonpublic information systems by an
-                        authorized user
-                        (or an information system) communicating through an external,
-                        nonorganization-controlled network. Remote access methods include, for
-                        example,
-                        dial-up, broadband, and wireless.
+                        authorized user (or an information system) communicating through an
+                        external, nonorganization-controlled network. Remote access methods
+                        include, for example, dial-up, broadband, and wireless.
 
                         This requirement only applies to components where this is specific to the
-                        function
-                        of the device or has the concept of an organizational user (e.g., VPN, proxy
-                        capability). This does not apply to authentication for the purpose of
-                        configuring
-                        the device itself
-                        (management).</ns0:description>
+                        function of the device or has the concept of an organizational user (e.g.,
+                        VPN, proxy capability). This does not apply to authentication for the
+                        purpose of configuring the device itself (management).</ns0:description>
                     <ns0:description>
                         <html:pre>Script Verification:
                             To manually verify, Ensure none of the following remote access packages
@@ -5260,40 +5138,31 @@
                     <ns0:title xml:lang="en">The operating system must require individuals to be
                         authenticated with an individual authenticator prior to using a group
                         authenticator.</ns0:title>
-                    <ns0:description xml:lang="en">To ensure individual accountability and prevent
-                        unauthorized access, organizational users must be individually identified
-                        and
-                        authenticated.
+                    <ns0:description xml:lang="en">To ensure individual accountability and
+                        prevent unauthorized access, organizational users must be individually
+                        identified and authenticated.
 
-                        A group authenticator is a generic account used by multiple individuals. Use
-                        of a
-                        group authenticator alone does not uniquely identify individual users.
-                        Examples of
-                        the group authenticator is the Unix OS "root" user account, the Windows
-                        "Administrator" account, the "sa" account, or a "helpdesk" account.
+                        A group authenticator is a generic account used by multiple
+                        individuals. Use of a group authenticator alone does not uniquely
+                        identify individual users. Examples of the group authenticator is the
+                        Unix OS "root" user account, the Windows "Administrator" account, the
+                        "sa" account, or a "helpdesk" account.
 
-                        For example, the Unix and Windows operating systems offer a "switch user"
-                        capability
-                        allowing users to authenticate with their individual credentials and, when
-                        needed,
-                        "switch" to the administrator role. This method provides for unique
-                        individual
-                        authentication prior to using a group authenticator.
+                        For example, the Unix and Windows operating systems offer a "switch
+                        user" capability allowing users to authenticate with their individual
+                        credentials and, when needed, "switch" to the administrator role. This
+                        method provides for unique individual authentication prior to using a
+                        group authenticator.
 
                         Users (and any processes acting on behalf of users) need to be uniquely
-                        identified
-                        and authenticated for all accesses other than those accesses explicitly
-                        identified
-                        and documented by the organization, which outlines specific user actions
-                        that can be
-                        performed on the operating system without identification or authentication.
-                        Requiring individuals to be authenticated with an individual authenticator
-                        prior to
-                        using a group authenticator allows for traceability of actions, as well as
-                        adding an
-                        additional level of protection of the actions that can be taken with group
-                        account
-                        knowledge.</ns0:description>
+                        identified and authenticated for all accesses other than those accesses
+                        explicitly identified and documented by the organization, which outlines
+                        specific user actions that can be performed on the operating system
+                        without identification or authentication. Requiring individuals to be
+                        authenticated with an individual authenticator prior to using a group
+                        authenticator allows for traceability of actions, as well as adding an
+                        additional level of protection of the actions that can be taken with
+                        group account knowledge.</ns0:description>
                     <ns0:description>
                         <html:pre>Script Verification:
                             To manually verify, Ensure none of the following remote access packages
@@ -5342,14 +5211,13 @@
                 <ns0:Rule id="xccdf_._rule_V_203642" selected="true" severity="medium">
                     <ns0:title xml:lang="en">The operating system must use multifactor
                         authentication for local access to privileged accounts.</ns0:title>
+
                     <ns0:description xml:lang="en">To ensure accountability and prevent
-                        unauthenticated
-                        access, privileged users must utilize multifactor authentication to prevent
-                        potential misuse and compromise of the system.
+                        unauthenticated access, privileged users must utilize multifactor
+                        authentication to prevent potential misuse and compromise of the system.
 
                         Multifactor authentication is defined as using two or more factors to
-                        achieve
-                        authentication.
+                        achieve authentication.
 
                         Factors include:
                         1) Something you know (e.g., password/PIN);
@@ -5358,14 +5226,11 @@
                         3) Something you are (e.g., biometric).
 
                         A privileged account is defined as an operating system account with
-                        authorizations
-                        of a privileged user.
+                        authorizations of a privileged user.
 
-                        Local access is defined as access to an organizational information system by
-                        a user
-                        (or process acting on behalf of a user) communicating through a direct
-                        connection
-                        without the use of a network.
+                        Local access is defined as access to an organizational information
+                        system by a user (or process acting on behalf of a user) communicating
+                        through a direct connection without the use of a network.
 
                         The DOD CAC with DOD-approved PKI is an example of multifactor
                         authentication.</ns0:description>
@@ -5503,28 +5368,19 @@
                         that is recognized and approved by the organization.</ns0:title>
                     <ns0:description xml:lang="en">Changes to any software components can have
                         significant effects on the overall security of the operating system. This
-                        requirement ensures the software has not been tampered with and that it has
-                        been
-                        provided by a trusted vendor.
+                        requirement ensures the software has not been tampered with and that
+                        it has been provided by a trusted vendor.
 
                         Accordingly, patches, service packs, device drivers, or operating system
-                        components
-                        must be signed with a certificate recognized and approved by the
-                        organization.
-                        Verifying the authenticity of the software prior to installation validates
-                        the
-                        integrity of the patch or upgrade received from a vendor. This ensures the
-                        software
-                        has not been tampered with and that it has been provided by a trusted
-                        vendor.
-                        Self-signed certificates are disallowed by this requirement. The operating
-                        system
-                        should not have to verify the software again. This requirement does not
-                        mandate DOD
-                        certificates for this purpose; however, the certificate used to verify the
-                        software
-                        must be from an approved
-                        CA.</ns0:description>
+                        components must be signed with a certificate recognized and approved by
+                        the organization. Verifying the authenticity of the software prior to
+                        installation validates the integrity of the patch or upgrade received
+                        from a vendor. This ensures the software has not been tampered with and
+                        that it has been provided by a trusted vendor. Self-signed certificates
+                        are disallowed by this requirement. The operating system should not
+                        have to verify the software again. This requirement does not mandate
+                        DOD certificates for this purpose; however, the certificate used to
+                        verify the software must be from an approved CA.</ns0:description>
                     <ns0:description>
                         <html:pre>Script Verification:
                             To manually verify, ensure all repositories in /etc/apk/repositories/
@@ -5611,22 +5467,16 @@
                 </ns0:Rule>
                 <ns0:Rule id="xccdf_._rule_V_203625" selected="true" severity="medium">
                     <ns0:title xml:lang="en">The operating system must enforce password complexity
-                        by requiring that at least
-                        one uppercase character be used.</ns0:title>
-                    <ns0:description xml:lang="en">Use of a complex password helps to increase the
-                        time
-                        and resources required to compromise the password. Password complexity, or
-                        strength,
-                        is a measure of the effectiveness of a password in resisting attempts at
-                        guessing
-                        and brute-force attacks.
+                        by requiring that at least one uppercase character be used.</ns0:title>
+                    <ns0:description xml:lang="en">Use of a complex password helps to increase
+                        the time and resources required to compromise the password. Password
+                        complexity, or strength, is a measure of the effectiveness of a password
+                        in resisting attempts at guessing and brute-force attacks.
 
                         Password complexity is one factor of several that determines how long it
-                        takes to
-                        crack a password. The more complex the password, the greater the number of
-                        possible
-                        combinations that need to be tested before the password is
-                        compromised.</ns0:description>
+                        takes to crack a password. The more complex the password, the greater
+                        the number of possible combinations that need to be tested before the
+                        password is compromised.</ns0:description>
                     <ns0:description>
                         <html:pre>Script Verification:
                             To manually verify, run command 'cat /etc/shadow and verify no password
@@ -5638,22 +5488,16 @@
                 </ns0:Rule>
                 <ns0:Rule id="xccdf_._rule_V_203626" selected="true" severity="medium">
                     <ns0:title xml:lang="en">The operating system must enforce password complexity
-                        by requiring that at least
-                        one lowercase character be used.</ns0:title>
-                    <ns0:description xml:lang="en">Use of a complex password helps to increase the
-                        time
-                        and resources required to compromise the password. Password complexity, or
-                        strength,
-                        is a measure of the effectiveness of a password in resisting attempts at
-                        guessing
-                        and brute-force attacks.
+                        by requiring that at least one lowercase character be used.</ns0:title>
+                    <ns0:description xml:lang="en">Use of a complex password helps to increase
+                        the time and resources required to compromise the password. Password
+                        complexity, or strength, is a measure of the effectiveness of a password
+                        in resisting attempts at guessing and brute-force attacks.
 
                         Password complexity is one factor of several that determines how long it
-                        takes to
-                        crack a password. The more complex the password, the greater the number of
-                        possible
-                        combinations that need to be tested before the password is
-                        compromised.</ns0:description>
+                        takes to crack a password. The more complex the password, the greater
+                        the number of possible combinations that need to be tested before the
+                        password is compromised.</ns0:description>
                     <ns0:description>
                         <html:pre>Script Verification:
                             To manually verify, run command 'cat /etc/shadow and verify no password
@@ -5731,14 +5575,11 @@
                 <ns0:Rule id="xccdf_._rule_V_203632" selected="true" severity="medium">
                     <ns0:title xml:lang="en">Operating systems must enforce a 60-day maximum
                         password lifetime restriction.</ns0:title>
-                    <ns0:description xml:lang="en">Any password, no matter how complex, can
-                        eventually
-                        be cracked; therefore, passwords need to be changed periodically. If the
-                        operating
-                        system does not limit the lifetime of passwords and force users to change
-                        their
-                        passwords, there is the risk that the operating system passwords could be
-                        compromised.</ns0:description>
+                    <ns0:description xml:lang="en">Any password, no matter how complex,
+                        can eventually be cracked; therefore, passwords need to be changed
+                        periodically. If the operating system does not limit the lifetime of
+                        passwords and force users to change their passwords, there is the risk
+                        that the operating system passwords could be compromised.</ns0:description>
                     <ns0:description>
                         <html:pre>Script Verification:
                             To manually verify, run command 'cat /etc/shadow and verify no password
@@ -5809,15 +5650,11 @@
             </ns0:Group>
             <ns0:Group id="xccdf_._group_No_Users">
                 <ns0:Rule id="xccdf_._rule_V_263650" selected="true" severity="medium">
-                    <ns0:title xml:lang="en">The operating system must disable accounts when the
-                        accounts are no
-                        longer
-                        associated to a user.</ns0:title>
+                    <ns0:title xml:lang="en">The operating system must disable accounts when
+                        the accounts are no longer associated to a user.</ns0:title>
                     <ns0:description xml:lang="en">Disabling expired, inactive, or otherwise
-                        anomalous
-                        accounts supports the concepts of least privilege and least functionality
-                        which
-                        reduce the attack surface of the
+                        anomalous accounts supports the concepts of least privilege
+                        and least functionality which reduce the attack surface of the
                         system.</ns0:description>
                     <ns0:description>
                         <html:pre>Script Verification:
@@ -5961,16 +5798,12 @@
                 </ns0:Rule>
                 <ns0:Rule id="xccdf_._rule_V_203725" selected="true" severity="medium">
                     <ns0:title xml:lang="en">The operating system must require users to
-                        reauthenticate when changing
-                        authenticators.</ns0:title>
+                        reauthenticate when changing authenticators.</ns0:title>
                     <ns0:description xml:lang="en">Without reauthentication, users may access
-                        resources
-                        or perform tasks for which they do not have authorization.
+                        resources or perform tasks for which they do not have authorization.
 
-                        When operating systems provide the capability to change user authenticators,
-                        it is
-                        critical the user
-                        reauthenticate.</ns0:description>
+                        When operating systems provide the capability to change user
+                        authenticators, it is critical the user reauthenticate.</ns0:description>
                     <ns0:description>
                         <html:pre>Script Verification:
                             To manually verify, run command 'cat /etc/shadow and verify that no
@@ -5984,13 +5817,10 @@
                     <ns0:title xml:lang="en">The operating system must require users to
                         reauthenticate when changing roles.</ns0:title>
                     <ns0:description xml:lang="en">Without reauthentication, users may access
-                        resources
-                        or perform tasks for which they do not have authorization.
+                        resources or perform tasks for which they do not have authorization.
 
-                        When operating systems provide the capability to change security roles, it
-                        is
-                        critical the user
-                        reauthenticate.</ns0:description>
+                        When operating systems provide the capability to change security roles,
+                        it is critical the user reauthenticate.</ns0:description>
                     <ns0:description>
                         <html:pre>Script Verification:
                             To manually verify, run command 'cat /etc/shadow and verify that no
@@ -6402,29 +6232,23 @@
             </ns0:Group>
             <ns0:Group id="xccdf_._group_Certificate_Audits">
                 <ns0:Rule id="xccdf_._rule_V_263659" selected="true" severity="medium">
-                    <ns0:title xml:lang="en">The operating system must include only approved trust
-                        anchors in trust
-                        stores or
-                        certificate stores managed by the organization.</ns0:title>
-                    <ns0:description xml:lang="en">Public key infrastructure (PKI) certificates are
-                        certificates with visibility external to organizational systems and
-                        certificates
-                        related to the internal operations of systems, such as application-specific
-                        time
-                        services. In cryptographic systems with a hierarchical structure, a trust
-                        anchor is
-                        an authoritative source (i.e., a certificate authority) for which trust is
-                        assumed
-                        and not derived. A root certificate for a PKI system is an example of a
-                        trust
-                        anchor. A trust store or certificate store maintains a list of trusted root
-                        certificates.</ns0:description>
+                    <ns0:title xml:lang="en">The operating system must include only approved
+                        trust anchors in trust stores or certificate stores managed by the
+                        organization.</ns0:title>
+                    <ns0:description xml:lang="en">Public key infrastructure (PKI) certificates
+                        are certificates with visibility external to organizational systems
+                        and certificates related to the internal operations of systems, such
+                        as application-specific time services. In cryptographic systems with
+                        a hierarchical structure, a trust anchor is an authoritative source
+                        (i.e., a certificate authority) for which trust is assumed and not
+                        derived. A root certificate for a PKI system is an example of a trust
+                        anchor. A trust store or certificate store maintains a list of trusted
+                        root certificates.</ns0:description>
                     <ns0:description>
                         <html:pre>Script Verification:
                             To manually verify, Ensure the ca-certificates package has not been
-                            modified
-                            using apk audit or by ensuring the sha256 value matches the trusted
-                            value. </html:pre>
+                            modified using apk audit or by ensuring the sha256 value matches
+                            the trusted value. </html:pre>
                     </ns0:description>
                     <ns0:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
                         <ns0:check-content-ref href="CertificateAuditTest.xml" />


### PR DESCRIPTION
In prior updates, some of the textual descriptions were updated with inconsistent formatting; re-flow the text descriptions to make them more readable.

Note that these changes are mostly not user visible; the html report generated by openscap reflows the text, the update here is mostly for the convenience of people looking at the xml document directly. The exception to this is the change to the xccdf_._rule_V_263659 "Script Verfication" section; this text is defined to be pre-formatted html and thus is emitted by openscap in its report as-is.