### PR TITLE
gitsign: add a policy for signing commits

### DIFF
--- a/.chainguard/source.yaml
+++ b/.chainguard/source.yaml
@@ -1,0 +1,10 @@
+# Copyright 2025 Chainguard, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+spec:
+  authorities:
+    - keyless:
+        # allow commits signed by users using GitHub or Google OIDC
+        identities:
+          - issuer: https://accounts.google.com
+          - issuer: https://github.com/login/oauth


### PR DESCRIPTION
Based on chainguard-dev/melange/.chainguard/source.yaml, though without the dependabot key allowed.