### PR TITLE
Revert checksum testing change

### DIFF
--- a/gpos/xml/scap/ssg/content/ssg-chainguard-gpos-ds.xml
+++ b/gpos/xml/scap/ssg/content/ssg-chainguard-gpos-ds.xml
@@ -6699,7 +6699,7 @@
       <states>
         <ind:filehash58_state id="oval:org.CABundleHash:ste:1" version="1">
           <ind:hash_type>SHA-256</ind:hash_type>
-          <ind:hash>8xf3f2d5222508ca469c78a347764ee1b1fab10a903172612c489ebcca05c91c</ind:hash>
+          <ind:hash>8cf3f2d5222508ca469c78a347764ee1b1fab10a903172612c489ebcca05c91c</ind:hash>
         </ind:filehash58_state>
       </states>
     </oval_definitions>


### PR DESCRIPTION
This was a last-minute, left-over change I was using to validate whether the checks were handling failures correctly.