### PR TITLE
fix RemoteAccessServicesTest: version-stream-aware pattern

### DIFF
--- a/gpos/xml/scap/ssg/content/ssg-chainguard-xccdf/OvalDefinitions/RemoteAccessServicesTest.xml
+++ b/gpos/xml/scap/ssg/content/ssg-chainguard-xccdf/OvalDefinitions/RemoteAccessServicesTest.xml
@@ -30,7 +30,7 @@
     <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:org.RemoteAccessServices:obj:6" version="1">
       <path>/lib/apk/db</path>
       <filename>installed</filename>
-      <pattern operation="pattern match">^P:(openssh|openssh-server|openssh-client|openssh-sftp-server|dropbear|tigervnc|tigervnc-server|tigervnc-viewer|xrdp|xorgxrdp|vsftpd|proftpd|webmin|cockpit|cockpit-ws|cockpit-bridge|nfs-utils|samba|samba-server|samba-client|samba-common|rsh|telnet)-*$</pattern>
+      <pattern operation="pattern match">^P:(openssh|openssh-server|openssh-client|openssh-sftp-server|dropbear|tigervnc|tigervnc-server|tigervnc-viewer|xrdp|xorgxrdp|vsftpd|proftpd|webmin|cockpit|cockpit-ws|cockpit-bridge|nfs-utils|samba|samba-server|samba-client|samba-common|rsh|telnet)(-\d[\d.]*(-[a-z][a-z0-9-]*)?)?$</pattern>
       <instance datatype="int">1</instance>
     </textfilecontent54_object>
   </objects>

--- a/gpos/xml/scap/ssg/content/ssg-chainguard-xccdf/OvalDefinitions/RemoteAccessServicesTest.xml
+++ b/gpos/xml/scap/ssg/content/ssg-chainguard-xccdf/OvalDefinitions/RemoteAccessServicesTest.xml
@@ -30,7 +30,7 @@
     <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:org.RemoteAccessServices:obj:6" version="1">
       <path>/lib/apk/db</path>
       <filename>installed</filename>
-      <pattern operation="pattern match">^P:(openssh|openssh-server|openssh-client|openssh-sftp-server|dropbear|tigervnc|tigervnc-server|tigervnc-viewer|xrdp|xorgxrdp|vsftpd|proftpd|webmin|cockpit|cockpit-ws|cockpit-bridge|nfs-utils|samba|samba-server|samba-client|samba-common|rsh|telnet)-*</pattern>
+      <pattern operation="pattern match">^P:(openssh|openssh-server|openssh-client|openssh-sftp-server|dropbear|tigervnc|tigervnc-server|tigervnc-viewer|xrdp|xorgxrdp|vsftpd|proftpd|webmin|cockpit|cockpit-ws|cockpit-bridge|nfs-utils|samba|samba-server|samba-client|samba-common|rsh|telnet)-*$</pattern>
       <instance datatype="int">1</instance>
     </textfilecontent54_object>
   </objects>


### PR DESCRIPTION
The `-*` suffix in the package pattern was doing nothing useful (zero or more literal dashes), and without a `$` anchor, packages like `samba-libs` and `samba-util-libs` matched `samba` as a prefix, causing false-positive No_Remote_Access failures.

Replaces the suffix with `(-\d[\d.]*(-[a-z][a-z0-9-]*)?)?$` to correctly handle version-streamed variants (`openssh-9.4`, `samba-4.19-client`) while rejecting alphabetic-only suffixes like `-libs` or `-keysign`.