### PR TITLE
chore(signature valdiation): allow prepare-release workflow, github validated signatures

### DIFF
--- a/.chainguard/source.yaml
+++ b/.chainguard/source.yaml
@@ -8,6 +8,13 @@ spec:
         identities:
           - issuer: https://accounts.google.com
           - issuer: https://github.com/login/oauth
+          # prepare-release action generated prs/commits
+          - issuer: https://token.actions.githubusercontent.com
+            subject: https://github.com/chainguard-dev/stigs/.github/workflows/prepare-release.yaml@refs/heads/main
     - key:
         # allow commits signed by GitHub, e.g. the UI
         kms: https://github.com/web-flow.gpg
+
+  # Allow Github verified ssh, gpg, and smime signatures
+  github:
+    verified: true


### PR DESCRIPTION
This is to fix https://github.com/chainguard-dev/stigs/pull/74