### PR TITLE
Updating the example code to use /bin/bash

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ This method scans an image in registry. **Note**: The target image must be prese
 docker run -i --rm -u 0:0 --pid=host \
   -v /var/run/docker.sock:/var/run/docker.sock \
   -v $(pwd)/out:/out \
-  --entrypoint sh \
+  --entrypoint /bin/bash \
   cgr.dev/chainguard/openscap:latest-dev <<_END_DOCKER_RUN
 oscap-docker image cgr.dev/chainguard/wolfi-base:latest xccdf eval \
   --profile "xccdf_basic_profile_.check" \
@@ -68,7 +68,7 @@ docker run --name target -d cgr.dev/chainguard/wolfi-base:latest tail -f /dev/nu
 docker run -i --rm -u 0:0 --pid=host \
   -v /var/run/docker.sock:/var/run/docker.sock \
   -v $(pwd)/out:/out \
-  --entrypoint sh \
+  --entrypoint /bin/bash \
   cgr.dev/chainguard/openscap:latest-dev <<_END_DOCKER_RUN
 oscap-docker container target xccdf eval \
   --profile "xccdf_basic_profile_.check" \

--- a/tests/e2e/run.sh
+++ b/tests/e2e/run.sh
@@ -145,7 +145,7 @@ for fixture in "${FIXTURES[@]}"; do
     -v /var/run/docker.sock:/var/run/docker.sock \
     -v "${REPO_ROOT}:/src:ro" \
     -v "${REPO_ROOT}/${out_sub}:/out" \
-    --entrypoint sh \
+    --entrypoint /bin/bash \
     "${SCAP_IMAGE}" -c "
       oscap-docker image '${tag}' xccdf eval \
         --profile '${PROFILE}' \


### PR DESCRIPTION
This came up because a customer was trying to use the example code with `:v1.4.4` instead of `:latest-dev`. 

The example code uses `--entrypoint sh` which only works on the `:latest-dev` image due to it being the only one of the images that has busybox installed. However, all of the images have `bash`. This PR updates the example code to use `--entrypoint /bin/bash` instead because it's more portable.