### PR TITLE
feat(oscap): add SSL_CERT_FILE environment-variable check

### DIFF
--- a/gpos/xml/scap/ssg/content/ssg-chainguard-gpos-ds.xml
+++ b/gpos/xml/scap/ssg/content/ssg-chainguard-gpos-ds.xml
@@ -133,6 +133,7 @@
         <ns0:select idref="xccdf_mil.disa.stig_rule_SV-263650r982553_rule" selected="true"/>
         <ns0:select idref="xccdf_mil.disa.stig_rule_SV-263652r982557_rule" selected="true"/>
         <ns0:select idref="xccdf_mil.disa.stig_rule_SV-263659r982563_rule" selected="true"/>
+        <ns0:select idref="xccdf_com.chainguard_rule_ssl_cert_file_env" selected="true"/>
       </ns0:Profile>
       <ns0:Group id="xccdf_._group_not_applicable_tests">
         <ns0:Rule id="xccdf_mil.disa.stig_rule_SV-263651r982555_rule" selected="true" severity="medium">
@@ -6248,7 +6249,17 @@
                     </ns0:description>
           <ns0:ident system="http://cyber.mil/cci">CCI-004909</ns0:ident>
           <ns0:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <ns0:check-content-ref href="CertificateAuditTest.xml"/>
+            <ns0:check-content-ref href="CertificateAuditTest.xml" name="oval:org.CABundleHash:def:1"/>
+          </ns0:check>
+        </ns0:Rule>
+        <ns0:Rule id="xccdf_com.chainguard_rule_ssl_cert_file_env" selected="true" severity="medium">
+          <ns0:title xml:lang="en">The SSL_CERT_FILE environment variable must reference the system CA bundle.</ns0:title>
+          <ns0:description xml:lang="en">Applications that honor SSL_CERT_FILE must be pointed at the
+                        organization-managed trust store. Ensure the SSL_CERT_FILE environment variable
+                        configured on the image or container is set to /etc/ssl/certs/ca-certificates.crt.</ns0:description>
+          <ns0:ident system="http://cyber.mil/cci">CCI-004909</ns0:ident>
+          <ns0:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+            <ns0:check-content-ref href="CertificateAuditTest.xml" name="oval:org.SslCertFileEnv:def:1"/>
           </ns0:check>
         </ns0:Rule>
       </ns0:Group>
@@ -6699,6 +6710,18 @@
             <criterion test_ref="oval:org.CABundleHash:tst:2" comment="Ensure CA bundle hash matches expected"/>
           </criteria>
         </definition>
+        <definition id="oval:org.SslCertFileEnv:def:1" version="1" class="compliance">
+          <metadata>
+            <title>SSL_CERT_FILE points to the system CA bundle</title>
+            <description>Ensure the SSL_CERT_FILE environment variable configured on the image or container is set to /etc/ssl/certs/ca-certificates.crt.</description>
+            <affected family="unix">
+              <platform>Chainguard</platform>
+            </affected>
+          </metadata>
+          <criteria>
+            <criterion test_ref="oval:org.SslCertFileEnv:tst:1" comment="SSL_CERT_FILE is set to the system CA bundle path"/>
+          </criteria>
+        </definition>
       </definitions>
       <tests>
         <unix:file_test id="oval:org.CABundleHash:tst:1" version="1" check="all" check_existence="only_one_exists" comment="Ensure CA bundle file exists">
@@ -6708,6 +6731,10 @@
           <ind:object object_ref="oval:org.CABundleHash:obj:2"/>
           <ind:state state_ref="oval:org.CABundleHash:ste:1"/>
         </ind:filehash58_test>
+        <ind:environmentvariable58_test id="oval:org.SslCertFileEnv:tst:1" version="1" check="all" check_existence="all_exist" comment="SSL_CERT_FILE equals /etc/ssl/certs/ca-certificates.crt">
+          <ind:object object_ref="oval:org.SslCertFileEnv:obj:1"/>
+          <ind:state state_ref="oval:org.SslCertFileEnv:ste:1"/>
+        </ind:environmentvariable58_test>
       </tests>
       <objects>
         <unix:file_object id="oval:org.CABundleHash:obj:1" version="1">
@@ -6717,12 +6744,19 @@
           <ind:filepath>/etc/ssl/certs/ca-certificates.crt</ind:filepath>
           <ind:hash_type>SHA-256</ind:hash_type>
         </ind:filehash58_object>
+        <ind:environmentvariable58_object id="oval:org.SslCertFileEnv:obj:1" version="1">
+          <ind:pid xsi:nil="true" datatype="int"/>
+          <ind:name>SSL_CERT_FILE</ind:name>
+        </ind:environmentvariable58_object>
       </objects>
       <states>
         <ind:filehash58_state id="oval:org.CABundleHash:ste:1" version="1">
           <ind:hash_type>SHA-256</ind:hash_type>
           <ind:hash>61efbd6d3f829f71039c57b29dd37d15ac7f33c4ece861aaef8c7d7a519cd1d9</ind:hash>
         </ind:filehash58_state>
+        <ind:environmentvariable58_state id="oval:org.SslCertFileEnv:ste:1" version="1">
+          <ind:value datatype="string" operation="equals">/etc/ssl/certs/ca-certificates.crt</ind:value>
+        </ind:environmentvariable58_state>
       </states>
     </oval_definitions>
   </ds:extended-component>

--- a/tests/oscap-offline/internal/scan/command.go
+++ b/tests/oscap-offline/internal/scan/command.go
@@ -42,6 +42,14 @@ const (
 	resultsFileName      = "results.xml"
 )
 
+// containerVarsEnv is the environment variable oscap's environmentvariable58
+// offline probe reads to source a scanned container's variables. Real
+// oscap-docker sets it from the target's Config.Env; the offline harness has no
+// daemon, so BuildArgs synthesizes it per-fixture. It is always set (empty when
+// a fixture declares no vars) so the probe uses the offline source rather than
+// falling back to an empty <OSCAP_PROBE_ROOT>/proc.
+const containerVarsEnv = "OSCAP_CONTAINER_VARS"
+
 // Environment variable names recognized by ConfigFromEnv.
 const (
 	envRuntime = "OSCAP_CONTAINER_RUNTIME"
@@ -98,7 +106,13 @@ func ConfigFromEnv(repoRoot, binaryPath string, getenv func(string) string) Conf
 // or a validated, cleaned path, and the argv is passed to exec as a slice with no
 // shell interpolation. An incomplete config or an unsafe path yields a wrapped
 // ErrInvalidConfig.
-func (c Config) BuildArgs(fixtureTar, resultsDir string) ([]string, error) {
+//
+// containerVars are the target's environment variables ("NAME=value" entries)
+// exposed to oscap's environmentvariable58 offline probe via OSCAP_CONTAINER_VARS
+// (newline-joined). It is fixture/config-controlled content, passed as a single
+// argv element with no shell, so it shares the existing argv trust boundary and
+// needs no metacharacter screening. Pass nil for fixtures with no relevant env.
+func (c Config) BuildArgs(fixtureTar, resultsDir string, containerVars []string) ([]string, error) {
 	if err := c.validate(); err != nil {
 		return nil, err
 	}
@@ -127,6 +141,7 @@ func (c Config) BuildArgs(fixtureTar, resultsDir string) ([]string, error) {
 		"-v", fixture + ":" + containerFixturePath + ":ro",
 		"-v", repoRoot + ":" + containerSrcPath + ":ro",
 		"-v", out + ":" + containerOutPath,
+		"-e", containerVarsEnv + "=" + strings.Join(containerVars, "\n"),
 		"--entrypoint", containerBinaryPath,
 		c.Image,
 		containerFixturePath,

--- a/tests/oscap-offline/internal/scan/command_test.go
+++ b/tests/oscap-offline/internal/scan/command_test.go
@@ -26,11 +26,12 @@ func TestBuildArgs(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name       string
-		mutate     func(*scan.Config)
-		fixtureTar string
-		resultsDir string
-		want       []string
+		name          string
+		mutate        func(*scan.Config)
+		fixtureTar    string
+		resultsDir    string
+		containerVars []string
+		want          []string
 	}{
 		{
 			name:       "default docker argv",
@@ -42,6 +43,7 @@ func TestBuildArgs(t *testing.T) {
 				"-v", "/work/fixture.tar:/in/fixture.tar:ro",
 				"-v", "/repo:/src:ro",
 				"-v", "/work/out:/out",
+				"-e", "OSCAP_CONTAINER_VARS=",
 				"--entrypoint", "/scan-offline",
 				"cgr.dev/chainguard/openscap@sha256:abc",
 				"/in/fixture.tar",
@@ -62,6 +64,7 @@ func TestBuildArgs(t *testing.T) {
 				"-v", "/work/fixture.tar:/in/fixture.tar:ro",
 				"-v", "/repo:/src:ro",
 				"-v", "/work/out:/out",
+				"-e", "OSCAP_CONTAINER_VARS=",
 				"--entrypoint", "/scan-offline",
 				"cgr.dev/chainguard/openscap@sha256:abc",
 				"/in/fixture.tar",
@@ -85,6 +88,7 @@ func TestBuildArgs(t *testing.T) {
 				"-v", "/work/fixture.tar:/in/fixture.tar:ro",
 				"-v", "/repo:/src:ro",
 				"-v", "/work/out:/out",
+				"-e", "OSCAP_CONTAINER_VARS=",
 				"--entrypoint", "/scan-offline",
 				"example.com/scap@sha256:deadbeef",
 				"/in/fixture.tar",
@@ -104,6 +108,30 @@ func TestBuildArgs(t *testing.T) {
 				"-v", "/work/fixture.tar:/in/fixture.tar:ro",
 				"-v", "/repo:/src:ro",
 				"-v", "/work/out:/out",
+				"-e", "OSCAP_CONTAINER_VARS=",
+				"--entrypoint", "/scan-offline",
+				"cgr.dev/chainguard/openscap@sha256:abc",
+				"/in/fixture.tar",
+				"xccdf", "eval",
+				"--profile", "xccdf_basic_profile_.check",
+				"--results", "/out/results.xml",
+				"/src/gpos/xml/scap/ssg/content/ssg-chainguard-gpos-ds.xml",
+			},
+		},
+		{
+			// Container vars are newline-joined into a single OSCAP_CONTAINER_VARS
+			// argv element, the offline source for the environmentvariable58 probe.
+			name:          "container vars are joined into OSCAP_CONTAINER_VARS",
+			fixtureTar:    "/work/fixture.tar",
+			resultsDir:    "/work/out",
+			containerVars: []string{"PATH=/bin", "SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt"},
+			want: []string{
+				"docker", "run", "--rm", "-u", "0:0", "--platform", "linux/amd64",
+				"-v", "/cache/scan-offline:/scan-offline:ro",
+				"-v", "/work/fixture.tar:/in/fixture.tar:ro",
+				"-v", "/repo:/src:ro",
+				"-v", "/work/out:/out",
+				"-e", "OSCAP_CONTAINER_VARS=PATH=/bin\nSSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt",
 				"--entrypoint", "/scan-offline",
 				"cgr.dev/chainguard/openscap@sha256:abc",
 				"/in/fixture.tar",
@@ -123,7 +151,7 @@ func TestBuildArgs(t *testing.T) {
 			if tc.mutate != nil {
 				tc.mutate(&cfg)
 			}
-			got, err := cfg.BuildArgs(tc.fixtureTar, tc.resultsDir)
+			got, err := cfg.BuildArgs(tc.fixtureTar, tc.resultsDir, tc.containerVars)
 			if err != nil {
 				t.Fatalf("BuildArgs: %v", err)
 			}
@@ -172,7 +200,7 @@ func TestBuildArgsRejectsInvalid(t *testing.T) {
 			if tc.mutate != nil {
 				tc.mutate(&cfg)
 			}
-			if _, err := cfg.BuildArgs(tc.fixtureTar, tc.resultsDir); !errors.Is(err, scan.ErrInvalidConfig) {
+			if _, err := cfg.BuildArgs(tc.fixtureTar, tc.resultsDir, nil); !errors.Is(err, scan.ErrInvalidConfig) {
 				t.Errorf("BuildArgs(%q, %q) err = %v, want ErrInvalidConfig", tc.fixtureTar, tc.resultsDir, err)
 			}
 		})
@@ -205,7 +233,7 @@ func TestBuildArgsAcceptsValidOverrides(t *testing.T) {
 
 			cfg := baseConfig()
 			tc.mutate(&cfg)
-			if _, err := cfg.BuildArgs("/work/fixture.tar", "/work/out"); err != nil {
+			if _, err := cfg.BuildArgs("/work/fixture.tar", "/work/out", nil); err != nil {
 				t.Errorf("BuildArgs rejected valid override: %v", err)
 			}
 		})

--- a/tests/oscap-offline/internal/scan/example_test.go
+++ b/tests/oscap-offline/internal/scan/example_test.go
@@ -20,14 +20,14 @@ func ExampleConfig_BuildArgs() {
 		Profile:           "xccdf_basic_profile_.check",
 	}
 
-	argv, err := cfg.BuildArgs("/work/fixture.tar", "/work/out")
+	argv, err := cfg.BuildArgs("/work/fixture.tar", "/work/out", []string{"SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt"})
 	if err != nil {
 		fmt.Println("build:", err)
 		return
 	}
 	fmt.Println(strings.Join(argv, " "))
 	// Output:
-	// docker run --rm -u 0:0 --platform linux/amd64 -v /cache/scan-offline:/scan-offline:ro -v /work/fixture.tar:/in/fixture.tar:ro -v /repo:/src:ro -v /work/out:/out --entrypoint /scan-offline cgr.dev/chainguard/openscap@sha256:abc /in/fixture.tar xccdf eval --profile xccdf_basic_profile_.check --results /out/results.xml /src/gpos/xml/scap/ssg/content/ssg-chainguard-gpos-ds.xml
+	// docker run --rm -u 0:0 --platform linux/amd64 -v /cache/scan-offline:/scan-offline:ro -v /work/fixture.tar:/in/fixture.tar:ro -v /repo:/src:ro -v /work/out:/out -e OSCAP_CONTAINER_VARS=SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt --entrypoint /scan-offline cgr.dev/chainguard/openscap@sha256:abc /in/fixture.tar xccdf eval --profile xccdf_basic_profile_.check --results /out/results.xml /src/gpos/xml/scap/ssg/content/ssg-chainguard-gpos-ds.xml
 }
 
 // ExampleConfigFromEnv shows defaults applied when no environment overrides are

--- a/tests/oscap-offline/internal/scan/fixtures_test.go
+++ b/tests/oscap-offline/internal/scan/fixtures_test.go
@@ -34,6 +34,7 @@ const (
 	ruleNoUsers                = "xccdf_mil.disa.stig_rule_SV-263650r982553_rule" // NoUsersCheck.xml
 	ruleVarLogPermissions      = "xccdf_mil.disa.stig_rule_SV-203664r958566_rule" // VarLogPermissionsTest.xml
 	ruleLibraryPermissions     = "xccdf_mil.disa.stig_rule_SV-203675r991560_rule" // LibraryPermissionsTest.xml
+	ruleSslCertFileEnv         = "xccdf_com.chainguard_rule_ssl_cert_file_env"    // SslCertFileEnv def in the certaudit component
 )
 
 // SCE rules excluded from the offline matrix. AslrCheck.sh reads the *live*
@@ -238,7 +239,9 @@ func buildHarness(t *testing.T) (harness, bool) {
 // scanFixture applies ops to the shared base bytes, runs a scan, and returns the
 // parsed report. Each call overlays from a fresh reader over the shared
 // immutable base bytes, so parallel subtests never contend on the source.
-func (h harness) scanFixture(t *testing.T, ops []overlay.Op) (results.Report, bool) {
+// containerVars are the fixture's OSCAP_CONTAINER_VARS entries, the offline
+// source for the environmentvariable58 probe (nil for fixtures with no env).
+func (h harness) scanFixture(t *testing.T, ops []overlay.Op, containerVars []string) (results.Report, bool) {
 	t.Helper()
 
 	fixture := bytes.NewBuffer(make([]byte, 0, len(h.baseBytes)+overlaySlack))
@@ -250,7 +253,7 @@ func (h harness) scanFixture(t *testing.T, ops []overlay.Op) (results.Report, bo
 		t.Fatalf("writing fixture: %v", err)
 	}
 
-	resultsPath, err := h.runner.Run(t.Context(), fixturePath, t.TempDir())
+	resultsPath, err := h.runner.Run(t.Context(), fixturePath, t.TempDir(), containerVars)
 	if err != nil {
 		// A scan that could not run at all (e.g. scanner image pull failure) is an
 		// availability gap: a skip in local dev, a failure under strict mode.
@@ -354,7 +357,11 @@ const (
 type matrixCase struct {
 	name string
 	ops  []overlay.Op
-	want map[string]results.Result
+	// containerVars are the OSCAP_CONTAINER_VARS entries ("NAME=value") the scan
+	// exposes to oscap's environmentvariable58 offline probe. nil for fixtures
+	// whose asserted rules do not read the container environment.
+	containerVars []string
+	want          map[string]results.Result
 }
 
 // matrixCases returns the offline scan matrix. Each row is one OVAL
@@ -494,6 +501,26 @@ func matrixCases() []matrixCase {
 			},
 			want: map[string]results.Result{ruleDetectOpenSsl: results.Fail},
 		},
+
+		// SslCertFileEnv reads the container environment via the
+		// environmentvariable58 offline probe (OSCAP_CONTAINER_VARS), not the
+		// rootfs, so these cases drive containerVars rather than overlay ops.
+		{
+			name:          "ssl_cert_file/pass_correct_value",
+			containerVars: []string{"SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt"},
+			want:          map[string]results.Result{ruleSslCertFileEnv: results.Pass},
+		},
+		{
+			name:          "ssl_cert_file/fail_wrong_value",
+			containerVars: []string{"SSL_CERT_FILE=/wrong/path.crt"},
+			want:          map[string]results.Result{ruleSslCertFileEnv: results.Fail},
+		},
+		{
+			// No SSL_CERT_FILE set: the var does not exist, so the all_exist test
+			// fails and the rule fails.
+			name: "ssl_cert_file/fail_unset",
+			want: map[string]results.Result{ruleSslCertFileEnv: results.Fail},
+		},
 	}
 }
 
@@ -522,7 +549,7 @@ func TestOfflineFixtureMatrix(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			report, ran := h.scanFixture(t, tc.ops)
+			report, ran := h.scanFixture(t, tc.ops, tc.containerVars)
 			if !ran {
 				// scanFixture skips or fatals when a scan cannot run, so this is
 				// only reached defensively.

--- a/tests/oscap-offline/internal/scan/scan.go
+++ b/tests/oscap-offline/internal/scan/scan.go
@@ -93,8 +93,8 @@ func NewRunner(cfg Config) Runner {
 // equivalent; registry operations elsewhere use go-containerregistry rather than
 // process execution. The argv is built by BuildArgs from validated config, so
 // every element is a constant or a validated path.
-func (r Runner) Run(ctx context.Context, fixtureTar, resultsDir string) (string, error) {
-	argv, err := r.cfg.BuildArgs(fixtureTar, resultsDir)
+func (r Runner) Run(ctx context.Context, fixtureTar, resultsDir string, containerVars []string) (string, error) {
+	argv, err := r.cfg.BuildArgs(fixtureTar, resultsDir, containerVars)
 	if err != nil {
 		return "", err
 	}

--- a/tests/oscap-offline/internal/scan/scan_test.go
+++ b/tests/oscap-offline/internal/scan/scan_test.go
@@ -53,7 +53,7 @@ func TestRunRejectsBadConfig(t *testing.T) {
 	t.Parallel()
 
 	runner := scan.NewRunner(scan.Config{}) // all empty -> invalid
-	if _, err := runner.Run(t.Context(), "/f.tar", "/out"); !errors.Is(err, scan.ErrInvalidConfig) {
+	if _, err := runner.Run(t.Context(), "/f.tar", "/out", nil); !errors.Is(err, scan.ErrInvalidConfig) {
 		t.Errorf("Run err = %v, want ErrInvalidConfig", err)
 	}
 }
@@ -75,7 +75,7 @@ func TestRunMissingResultsNamesCause(t *testing.T) {
 	runner := scan.NewRunner(cfg)
 
 	resultsDir := t.TempDir() // empty: results.xml will be absent
-	_, err := runner.Run(t.Context(), "/work/fixture.tar", resultsDir)
+	_, err := runner.Run(t.Context(), "/work/fixture.tar", resultsDir, nil)
 	if !errors.Is(err, scan.ErrScanFailed) {
 		t.Fatalf("Run err = %v, want ErrScanFailed", err)
 	}


### PR DESCRIPTION
## What

Adds a compliance check asserting that the `SSL_CERT_FILE` environment
variable configured on the scanned image/container equals the system CA
bundle path `/etc/ssl/certs/ca-certificates.crt`.

## How it works

The check uses OVAL's `environmentvariable58` probe. In offline mode
(`OSCAP_PROBE_ROOT` set — which is how `oscap-docker` always runs) this
probe does **not** read `/proc`; it reads the target's variables from
`OSCAP_CONTAINER_VARS`. `oscap-docker` sets that from the target's
`Config.Env`, so:

- `oscap-docker image <ref>` → sees the image's `ENV`
- `oscap-docker container <name>` → sees image `ENV` + runtime `-e` overrides

No daemon calls, wrapper step, or SCE script required.

## Datastream

The OVAL definition lives inside the existing `certaudit` component, next
to the `/etc/ssl/certs/ca-certificates.crt` file/hash checks, as an
independent definition (`oval:org.SslCertFileEnv:def:1`) wired to a new
rule (`xccdf_com.chainguard_rule_ssl_cert_file_env`) via a
`check-content-ref` `name`. The existing CA-hash rule gains a matching
`name` so it stays unambiguous now that the component holds two
definitions. The existing CA rule's semantics are unchanged.

## Offline harness

The Go harness previously set only `OSCAP_PROBE_ROOT`, so the env probe
collected nothing. `BuildArgs`/`Run` now thread a per-fixture
`OSCAP_CONTAINER_VARS` via `docker run -e` (always set, empty when a
fixture declares none, so the probe never falls back to an empty
`/proc`). The offline matrix gains `ssl_cert_file/{pass_correct_value,
fail_wrong_value, fail_unset}`.

## Testing

- `oscap ds sds-validate` on the datastream: PASS.
- Offline matrix: all fixtures pass, including the 3 new cases, with no
  regression to the existing rules.
- e2e gets this for free — `wolfi-base` already ships
  `SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
