### PR TITLE
test(oscap): re-pin wolfi-base digest in parseWolfiBaseRef test

### DIFF
--- a/tests/oscap-offline/internal/scan/fixtures_test.go
+++ b/tests/oscap-offline/internal/scan/fixtures_test.go
@@ -574,7 +574,7 @@ func TestSCERulesExcludedFromMatrix(t *testing.T) {
 func TestParseWolfiBaseRef(t *testing.T) {
 	t.Parallel()
 
-	const pinned = wolfiBaseRepo + ":latest@sha256:2f7a5c164eafbdbe46fe1d91bd1ab4c8cb5c2bdbd10641c3d61bd39962384cdb"
+	const pinned = wolfiBaseRepo + ":latest@sha256:02dab76bd852a70556b5b2002195c8a5fdab77d323c433bf6642aab080489795"
 
 	realDockerfile, err := os.ReadFile(filepath.Clean(filepath.Join("..", "..", "..", "e2e", "fixtures", "baseline-clean", "Dockerfile")))
 	if err != nil {


### PR DESCRIPTION
## What

Fixes a stale test constant. `TestParseWolfiBaseRef`'s `pinned` constant
still held the old wolfi-base digest and no longer matched
`tests/e2e/fixtures/baseline-clean/Dockerfile` after that Dockerfile was
re-pinned in 89d0868, so the `real_baseline_clean_dockerfile` subtest
failed:

```
--- FAIL: TestParseWolfiBaseRef/real_baseline_clean_dockerfile
    parseWolfiBaseRef ref mismatch (-want +got):
    - "2f7a5c164eafbdbe46fe1d91bd1ab4c8cb5c2bdbd10641c3d61bd39962384cdb"
    + "02dab76bd852a70556b5b2002195c8a5fdab77d323c433bf6642aab080489795"
```

This updates the constant to the current digest.

## Testing

`go test -run TestParseWolfiBaseRef ./internal/scan/` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
