### PR TITLE
feat(oscap): assert OPENSSL_CONF in the OpenSSL FIPS check

### DIFF
--- a/gpos/xml/scap/ssg/content/ssg-chainguard-gpos-ds.xml
+++ b/gpos/xml/scap/ssg/content/ssg-chainguard-gpos-ds.xml
@@ -6323,7 +6323,7 @@
         <definition id="oval:org.OpenSsl:def:1" version="1" class="compliance">
           <metadata>
             <title>Check for OpenSSL FIPS Packages</title>
-            <description>Ensure that the necessary OpenSSL FIPS packages and configuration files are present.</description>
+            <description>Ensure that the necessary OpenSSL FIPS packages and configuration files are present, and that the OPENSSL_CONF environment variable is either unset or set to /etc/ssl/openssl.cnf.</description>
             <reference source="CIS"/>
             <affected family="unix">
               <platform>Chainguard</platform>
@@ -6337,6 +6337,7 @@
             <criterion comment="Check that fipsmodule.cnf is included in openssl.cnf" test_ref="oval:org.OpenSsl:tst:5"/>
             <criterion comment="openssl.cnf: check that FIPS provider is enabled in provider_sect" test_ref="oval:org.OpenSsl:tst:6"/>
             <criterion comment="openssl.cnf: check that default_properties is set to fips=yes" test_ref="oval:org.OpenSsl:tst:7"/>
+            <criterion comment="OPENSSL_CONF is unset or set to /etc/ssl/openssl.cnf" test_ref="oval:org.OpenSsl:tst:8"/>
           </criteria>
         </definition>
       </definitions>
@@ -6362,6 +6363,10 @@
         <independent:textfilecontent54_test xmlns:independent="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:org.OpenSsl:tst:7" version="1" check="all" check_existence="all_exist" comment="openssl.cnf: check that default_properties is set to fips=yes">
           <independent:object object_ref="oval:org.OpenSsl:obj:7"/>
         </independent:textfilecontent54_test>
+        <independent:environmentvariable58_test xmlns:independent="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:org.OpenSsl:tst:8" version="1" check="all" check_existence="any_exist" comment="OPENSSL_CONF is unset or set to /etc/ssl/openssl.cnf">
+          <independent:object object_ref="oval:org.OpenSsl:obj:8"/>
+          <independent:state state_ref="oval:org.OpenSsl:ste:1"/>
+        </independent:environmentvariable58_test>
       </tests>
       <objects>
         <!-- obj:1 collects any file under /etc/ssl whose basename contains
@@ -6407,7 +6412,22 @@
           <independent:pattern operation="pattern match">^\s*default_properties\s*=\s*fips=yes\s*$</independent:pattern>
           <independent:instance datatype="int" operation="greater than or equal">1</independent:instance>
         </independent:textfilecontent54_object>
+        <!-- obj:8 reads the OPENSSL_CONF environment variable configured on the
+             scanned image/container. In offline mode oscap sources it from
+             OSCAP_CONTAINER_VARS (the target's Config.Env), which oscap-docker
+             populates. Paired with tst:8's any_exist + check=all, the criterion
+             is satisfied when OPENSSL_CONF is unset OR set to
+             /etc/ssl/openssl.cnf. -->
+        <independent:environmentvariable58_object xmlns:independent="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:org.OpenSsl:obj:8" version="1">
+          <independent:pid xsi:nil="true" datatype="int"/>
+          <independent:name>OPENSSL_CONF</independent:name>
+        </independent:environmentvariable58_object>
       </objects>
+      <states>
+        <independent:environmentvariable58_state xmlns:independent="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:org.OpenSsl:ste:1" version="1">
+          <independent:value datatype="string" operation="equals">/etc/ssl/openssl.cnf</independent:value>
+        </independent:environmentvariable58_state>
+      </states>
     </oval_definitions>
   </ds:extended-component>
   <ds:extended-component id="scap_org_ecomp_.librarypermissions" timestamp="2024-05-29T12:00:00">

--- a/gpos/xml/scap/ssg/content/ssg-chainguard-xccdf/OvalDefinitions/DetectOpenSslTest.xml
+++ b/gpos/xml/scap/ssg/content/ssg-chainguard-xccdf/OvalDefinitions/DetectOpenSslTest.xml
@@ -10,7 +10,7 @@
     <definition id="oval:org.OpenSsl:def:1" version="1" class="compliance">
       <metadata>
         <title>Check for OpenSSL FIPS Packages</title>
-        <description>Ensure that the necessary OpenSSL FIPS packages and configuration files are present.</description>
+        <description>Ensure that the necessary OpenSSL FIPS packages and configuration files are present, and that the OPENSSL_CONF environment variable is either unset or set to /etc/ssl/openssl.cnf.</description>
         <reference source="Custom"/>
         <affected family="unix">
           <platform>Chainguard</platform>
@@ -24,6 +24,7 @@
         <criterion comment="Check that fipsmodule.cnf is included in openssl.cnf" test_ref="oval:org.OpenSsl:tst:5"/>
         <criterion comment="openssl.cnf: check that FIPS provider is enabled in provider_sect" test_ref="oval:org.OpenSsl:tst:6"/>
         <criterion comment="openssl.cnf: check that default_properties is set to fips=yes" test_ref="oval:org.OpenSsl:tst:7"/>
+        <criterion comment="OPENSSL_CONF is unset or set to /etc/ssl/openssl.cnf" test_ref="oval:org.OpenSsl:tst:8"/>
       </criteria>
     </definition>
   </definitions>
@@ -49,6 +50,10 @@
     <independent:textfilecontent54_test xmlns:independent="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:org.OpenSsl:tst:7" version="1" check="all" check_existence="all_exist" comment="openssl.cnf: check that default_properties is set to fips=yes">
       <independent:object object_ref="oval:org.OpenSsl:obj:7"/>
     </independent:textfilecontent54_test>
+    <independent:environmentvariable58_test xmlns:independent="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:org.OpenSsl:tst:8" version="1" check="all" check_existence="any_exist" comment="OPENSSL_CONF is unset or set to /etc/ssl/openssl.cnf">
+      <independent:object object_ref="oval:org.OpenSsl:obj:8"/>
+      <independent:state state_ref="oval:org.OpenSsl:ste:1"/>
+    </independent:environmentvariable58_test>
   </tests>
   <objects>
     <!-- obj:1 collects any file under /etc/ssl whose basename contains "fipsmodule"
@@ -94,5 +99,19 @@
       <independent:pattern operation="pattern match">^\s*default_properties\s*=\s*fips=yes\s*$</independent:pattern>
       <independent:instance datatype="int" operation="greater than or equal">1</independent:instance>
     </independent:textfilecontent54_object>
+    <!-- obj:8 reads the OPENSSL_CONF environment variable configured on the
+         scanned image/container. In offline mode oscap sources it from
+         OSCAP_CONTAINER_VARS (the target's Config.Env), which oscap-docker
+         populates. Paired with tst:8's any_exist + check=all, the criterion is
+         satisfied when OPENSSL_CONF is unset OR set to /etc/ssl/openssl.cnf. -->
+    <independent:environmentvariable58_object xmlns:independent="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:org.OpenSsl:obj:8" version="1">
+      <independent:pid xsi:nil="true" datatype="int"/>
+      <independent:name>OPENSSL_CONF</independent:name>
+    </independent:environmentvariable58_object>
   </objects>
+  <states>
+    <independent:environmentvariable58_state xmlns:independent="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:org.OpenSsl:ste:1" version="1">
+      <independent:value datatype="string" operation="equals">/etc/ssl/openssl.cnf</independent:value>
+    </independent:environmentvariable58_state>
+  </states>
 </oval_definitions>

--- a/tests/oscap-offline/internal/scan/fixtures_test.go
+++ b/tests/oscap-offline/internal/scan/fixtures_test.go
@@ -482,6 +482,9 @@ func matrixCases() []matrixCase {
 			want: map[string]results.Result{ruleDetectOpenSsl: results.Fail},
 		},
 		{
+			// All FIPS files/packages present and OPENSSL_CONF unset: the
+			// OPENSSL_CONF criterion (any_exist + check=all) is vacuously satisfied
+			// when the variable is absent, so the rule passes.
 			name: "detect_openssl/pass_fips_present",
 			ops: []overlay.Op{
 				overlay.AddFile("etc/ssl/fipsmodule.cnf", fipsModuleCnf, 0o644, 0, 0),
@@ -489,6 +492,30 @@ func matrixCases() []matrixCase {
 				overlay.AppendFile("usr/lib/apk/db/installed", apkFIPSPackages),
 			},
 			want: map[string]results.Result{ruleDetectOpenSsl: results.Pass},
+		},
+		{
+			// FIPS present and OPENSSL_CONF explicitly set to the sanctioned path:
+			// the OPENSSL_CONF criterion is satisfied, so the rule passes.
+			name: "detect_openssl/pass_openssl_conf_correct",
+			ops: []overlay.Op{
+				overlay.AddFile("etc/ssl/fipsmodule.cnf", fipsModuleCnf, 0o644, 0, 0),
+				overlay.AddFile("etc/ssl/openssl.cnf", opensslCnf, 0o644, 0, 0),
+				overlay.AppendFile("usr/lib/apk/db/installed", apkFIPSPackages),
+			},
+			containerVars: []string{"OPENSSL_CONF=/etc/ssl/openssl.cnf"},
+			want:          map[string]results.Result{ruleDetectOpenSsl: results.Pass},
+		},
+		{
+			// FIPS otherwise valid but OPENSSL_CONF points elsewhere: the
+			// OPENSSL_CONF criterion fails, so the AND'd rule fails.
+			name: "detect_openssl/fail_openssl_conf_wrong",
+			ops: []overlay.Op{
+				overlay.AddFile("etc/ssl/fipsmodule.cnf", fipsModuleCnf, 0o644, 0, 0),
+				overlay.AddFile("etc/ssl/openssl.cnf", opensslCnf, 0o644, 0, 0),
+				overlay.AppendFile("usr/lib/apk/db/installed", apkFIPSPackages),
+			},
+			containerVars: []string{"OPENSSL_CONF=/wrong/openssl.cnf"},
+			want:          map[string]results.Result{ruleDetectOpenSsl: results.Fail},
 		},
 		{
 			// Config files present but only the *doc* subpackages installed: the


### PR DESCRIPTION
## What

Adds an `OPENSSL_CONF` environment-variable assertion to the existing
OpenSSL FIPS compliance check (`oval:org.OpenSsl:def:1`, rule
`SV-203739`) — **not** as a new rule, group, or definition. The variable
must be **unset**, or if set, must equal `/etc/ssl/openssl.cnf`.

## How

An eighth `AND` criterion (`tst:8`) on the existing definition, using an
`environmentvariable58` test with `check_existence="any_exist"` +
`check="all"` against a state of `/etc/ssl/openssl.cnf`:

- `any_exist` tolerates an absent variable, and
- `check="all"` is vacuously true over zero collected items,

so the criterion passes when `OPENSSL_CONF` is unset **and** when it is
set to the sanctioned path, and fails only when it is set to anything
else. In offline scans oscap sources the value from
`OSCAP_CONTAINER_VARS` (the target's `Config.Env`), which `oscap-docker`
populates from the scanned image/container.

The `tst:8`/`obj:8`/`ste:1` triple is added to **both** the standalone
`OvalDefinitions/DetectOpenSslTest.xml` and the embedded copy in the
datastream, kept in sync.

## Testing

- `oscap oval validate` (standalone) and `oscap ds sds-validate`
  (datastream): pass.
- OVAL semantics verified: unset -> pass, `/etc/ssl/openssl.cnf` -> pass,
  any other value -> fail.
- Offline matrix gains `detect_openssl/pass_openssl_conf_correct` and
  `detect_openssl/fail_openssl_conf_wrong`; `pass_fips_present` documents
  that the unset case is allowed. Full offline module is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
