### PR TITLE
Redefine NoUsers check to permit locked shadow entries

### DIFF
--- a/gpos/xml/scap/ssg/content/ssg-chainguard-gpos-ds.xml
+++ b/gpos/xml/scap/ssg/content/ssg-chainguard-gpos-ds.xml
@@ -5658,8 +5658,7 @@
                         anomalous accounts supports the concepts of least privilege and least
                         functionality which reduce the attack surface of the system. <html:pre>
                         Script Verification:
-                            To manually verify, run command 'cat /etc/shadow and verify that no
-                        additional users exist
+                            To manually verify, run command 'cat /etc/shadow and verify that every entry's password field is locked ('!' or '*'), i.e. no login-capable users exist
                         </html:pre>
                     </ns0:description>
           <ns0:ident system="http://cyber.mil/cci">CCI-003628</ns0:ident>
@@ -5681,8 +5680,7 @@
                         mechanisms or malicious code protection mechanisms are examples of
                         privileged functions that require protection from non-privileged users. <html:pre>
                         Script Verification:
-                            To manually verify, run command 'cat /etc/shadow and verify that no
-                        additional users exist
+                            To manually verify, run command 'cat /etc/shadow and verify that every entry's password field is locked ('!' or '*'), i.e. no login-capable users exist
                         </html:pre>
                     </ns0:description>
           <ns0:ident system="http://cyber.mil/cci">CCI-002235</ns0:ident>
@@ -5698,8 +5696,7 @@
                         ensures that when new accounts are created they do not have unnecessary
                         access. <html:pre>
                             Script Verification:
-                            To manually verify, run command 'cat /etc/shadow and verify that no
-                        additional users exist
+                            To manually verify, run command 'cat /etc/shadow and verify that every entry's password field is locked ('!' or '*'), i.e. no login-capable users exist
                         </html:pre>
                     </ns0:description>
           <ns0:ident system="http://cyber.mil/cci">CCI-000366</ns0:ident>
@@ -5723,8 +5720,7 @@
                         identified and documented by the organization when related to the use of
                         anonymous access. <html:pre>
                             Script Verification:
-                            To manually verify, run command 'cat /etc/shadow and verify that no
-                        additional users exist
+                            To manually verify, run command 'cat /etc/shadow and verify that every entry's password field is locked ('!' or '*'), i.e. no login-capable users exist
                         </html:pre>
                     </ns0:description>
           <ns0:ident system="http://cyber.mil/cci">CCI-000804</ns0:ident>
@@ -5754,8 +5750,7 @@
                         authentication/access mechanisms that meet or exceed access control policy
                         requirements. <html:pre>
                             Script Verification:
-                            To manually verify, run command 'cat /etc/shadow and verify that no
-                        additional users exist
+                            To manually verify, run command 'cat /etc/shadow and verify that every entry's password field is locked ('!' or '*'), i.e. no login-capable users exist
                         </html:pre>
                     </ns0:description>
           <ns0:ident system="http://cyber.mil/cci">CCI-001682</ns0:ident>
@@ -5785,8 +5780,7 @@
                         isolating the administrative interface on a different security domain and
                         with additional access controls. <html:pre>
                             Script Verification:
-                            To manually verify, run command 'cat /etc/shadow and verify that no
-                        dditional users exist
+                            To manually verify, run command 'cat /etc/shadow and verify that every entry's password field is locked ('!' or '*'), i.e. no login-capable users exist
                         </html:pre>
                     </ns0:description>
           <ns0:ident system="http://cyber.mil/cci">CCI-001082</ns0:ident>
@@ -5802,8 +5796,7 @@
                         operating systems provide the capability to change user authenticators, it
                         is critical the user reauthenticate. <html:pre>
                             Script Verification:
-                            To manually verify, run command 'cat /etc/shadow and verify that no
-                        additional users exist
+                            To manually verify, run command 'cat /etc/shadow and verify that every entry's password field is locked ('!' or '*'), i.e. no login-capable users exist
                         </html:pre>
                     </ns0:description>
           <ns0:ident system="http://cyber.mil/cci">CCI-002038</ns0:ident>
@@ -5819,8 +5812,7 @@
                         operating systems provide the capability to change security roles, it is
                         critical the user reauthenticate. <html:pre>
                             Script Verification:
-                            To manually verify, run command 'cat /etc/shadow and verify that no
-                        additional users exist
+                            To manually verify, run command 'cat /etc/shadow and verify that every entry's password field is locked ('!' or '*'), i.e. no login-capable users exist
                         </html:pre>
                     </ns0:description>
           <ns0:ident system="http://cyber.mil/cci">CCI-002038</ns0:ident>
@@ -5843,8 +5835,7 @@
                         authentication/access/auditing mechanisms that meet or exceed access control
                         policy requirements. <html:pre>
                             Script Verification:
-                            To manually verify, run command 'cat /etc/shadow and verify that no
-                        additional users exist
+                            To manually verify, run command 'cat /etc/shadow and verify that every entry's password field is locked ('!' or '*'), i.e. no login-capable users exist
                         </html:pre>
                     </ns0:description>
           <ns0:ident system="http://cyber.mil/cci">CCI-000015</ns0:ident>
@@ -5867,8 +5858,7 @@
                         authentication/access/auditing mechanisms that meet or exceed access control
                         policy requirements. <html:pre>
                             Script Verification:
-                            To manually verify, run command 'cat /etc/shadow and verify that no
-                        additional users exist
+                            To manually verify, run command 'cat /etc/shadow and verify that every entry's password field is locked ('!' or '*'), i.e. no login-capable users exist
                         </html:pre>
                     </ns0:description>
           <ns0:ident system="http://cyber.mil/cci">CCI-000015</ns0:ident>
@@ -5895,8 +5885,7 @@
                         unique identification of individuals in group accounts (e.g., shared
                         privilege accounts) or for detailed accountability of individual activity. <html:pre>
                         Script Verification:
-                            To manually verify, run command 'cat /etc/shadow and verify that no
-                        additional users exist
+                            To manually verify, run command 'cat /etc/shadow and verify that every entry's password field is locked ('!' or '*'), i.e. no login-capable users exist
                         </html:pre>
                     </ns0:description>
           <ns0:ident system="http://cyber.mil/cci">CCI-000764</ns0:ident>
@@ -5916,8 +5905,7 @@
                         are required to operate at a higher privilege level and therefore should be
                         excluded from the organization-defined software list after review.
                         ScriptVerification:
-                        To manually verify, run command 'cat /etc/shadow and verify that no
-                        additional users exist
+                        To manually verify, run command 'cat /etc/shadow and verify that every entry's password field is locked ('!' or '*'), i.e. no login-capable users exist
                     </ns0:description>
           <ns0:ident system="http://cyber.mil/cci">CCI-002233</ns0:ident>
           <ns0:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
@@ -5952,8 +5940,7 @@
                         identity-based access control, that limitation is not required for this use
                         of discretionary access control. <html:pre>
                             Script Verification:
-                            To manually verify, run command 'cat /etc/shadow and verify that no
-                        additional users exist
+                            To manually verify, run command 'cat /etc/shadow and verify that every entry's password field is locked ('!' or '*'), i.e. no login-capable users exist
                         </html:pre>
                     </ns0:description>
           <ns0:ident system="http://cyber.mil/cci">CCI-002165</ns0:ident>
@@ -5977,8 +5964,7 @@
                         authentication/access mechanisms that meet or exceed access control policy
                         requirements. <html:pre>
                             Script Verification:
-                            To manually verify, run command 'cat /etc/shadow and verify that no
-                        additional users exist
+                            To manually verify, run command 'cat /etc/shadow and verify that every entry's password field is locked ('!' or '*'), i.e. no login-capable users exist
                         </html:pre>
                     </ns0:description>
           <ns0:ident system="http://cyber.mil/cci">CCI-000016</ns0:ident>
@@ -6014,8 +6000,7 @@
                         using automated telephonic notification to report atypical system account
                         usage. <html:pre>
                             Script Verification:
-                            To manually verify, run command 'cat /etc/shadow and verify that no
-                        additional users exist
+                            To manually verify, run command 'cat /etc/shadow and verify that every entry's password field is locked ('!' or '*'), i.e. no login-capable users exist
                         </html:pre>
                     </ns0:description>
           <ns0:ident system="http://cyber.mil/cci">CCI-000015</ns0:ident>
@@ -6031,8 +6016,7 @@
                         information of a sensitive nature. Non-privileged users should coordinate
                         any sharing of information with an SA through shared resources. <html:pre>
                         Script Verification:
-                            To manually verify, run command 'cat /etc/shadow and verify that no
-                        additional users exist
+                            To manually verify, run command 'cat /etc/shadow and verify that every entry's password field is locked ('!' or '*'), i.e. no login-capable users exist
                         </html:pre>
                     </ns0:description>
           <ns0:ident system="http://cyber.mil/cci">CCI-000366</ns0:ident>
@@ -6049,8 +6033,7 @@
                         users. The organization must maintain audit trails in sufficient detail to
                         reconstruct events to determine the actual account involved in the activity. <html:pre>
                         Script Verification:
-                            To manually verify, run command 'cat /etc/shadow and verify that no
-                        additional users exist
+                            To manually verify, run command 'cat /etc/shadow and verify that every entry's password field is locked ('!' or '*'), i.e. no login-capable users exist
                         </html:pre>
                     </ns0:description>
           <ns0:ident system="http://cyber.mil/cci">CCI-000135</ns0:ident>
@@ -6068,8 +6051,7 @@
                         been obtained. Operating systems need to track periods of inactivity and
                         disable application identifiers after 35 days of inactivity. <html:pre>
                         Script Verification:
-                            To manually verify, run command 'cat /etc/shadow and verify that no
-                        additional users exist
+                            To manually verify, run command 'cat /etc/shadow and verify that every entry's password field is locked ('!' or '*'), i.e. no login-capable users exist
                         </html:pre>
                     </ns0:description>
           <ns0:ident system="http://cyber.mil/cci">CCI-003627</ns0:ident>
@@ -6494,44 +6476,34 @@
         <oval:timestamp>2024-05-29T12:00:00</oval:timestamp>
       </generator>
       <definitions>
-        <definition id="oval:org.NoUsers:def:1" version="1" class="compliance">
+        <definition id="oval:org.NoUsers:def:1" version="2" class="compliance">
           <metadata>
-            <title>Check for Unauthorized Users in /etc/shadow</title>
-            <description>Ensure there are no unauthorized users in the /etc/shadow file below the 'nobody' line.</description>
+            <title>Check for Login-Capable Users in /etc/shadow</title>
+            <description>Ensure every entry in /etc/shadow is locked (password field starts with '!' or '*'), i.e. there are no login-capable user accounts. Locked service accounts, such as those apko creates for image run-as users, cannot log in and are permitted.</description>
             <reference source="CIS"/>
             <affected family="unix">
               <platform>Chainguard</platform>
             </affected>
           </metadata>
           <criteria operator="AND">
-            <criterion comment="Check that the 'nobody' line is present" test_ref="oval:org.NoUsers:tst:1"/>
-            <criterion comment="Check for unauthorized users after the 'nobody' line" test_ref="oval:org.NoUsers:tst:2"/>
+            <criterion comment="Check that no unlocked entries exist in /etc/shadow" test_ref="oval:org.NoUsers:tst:1"/>
           </criteria>
         </definition>
       </definitions>
       <tests>
-        <!-- Test to check the presence of 'nobody' line -->
-        <textfilecontent54_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" check="all" check_existence="at_least_one_exists" comment="Check presence of 'nobody' line in /etc/shadow" id="oval:org.NoUsers:tst:1" version="1">
+        <!-- Test that no entry has an unlocked (login-capable) password field -->
+        <textfilecontent54_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" check="all" check_existence="none_exist" comment="Check for unlocked entries in /etc/shadow" id="oval:org.NoUsers:tst:1" version="2">
           <object object_ref="oval:org.NoUsers:obj:1"/>
-        </textfilecontent54_test>
-        <!-- Test to check for any lines after 'nobody' -->
-        <textfilecontent54_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" check="all" check_existence="none_exist" comment="Check for unauthorized users after the 'nobody' line in /etc/shadow" id="oval:org.NoUsers:tst:2" version="1">
-          <object object_ref="oval:org.NoUsers:obj:2"/>
         </textfilecontent54_test>
       </tests>
       <objects>
-        <!-- Object to find the 'nobody' line -->
-        <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:org.NoUsers:obj:1" version="1">
+        <!-- Object matching any entry whose password field does not start with '!' or '*'.
+             This intentionally matches empty password fields (passwordless login) too.
+             Same pattern as UserPasswordConfiguredTest's oval:org.example:obj:6. -->
+        <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:org.NoUsers:obj:1" version="2">
           <path>/etc</path>
           <filename>shadow</filename>
-          <pattern operation="pattern match">^nobody:.*</pattern>
-          <instance datatype="int">1</instance>
-        </textfilecontent54_object>
-        <!-- Object to find any lines after 'nobody' -->
-        <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:org.NoUsers:obj:2" version="1">
-          <path>/etc</path>
-          <filename>shadow</filename>
-          <pattern operation="pattern match">^nobody:.*\n(.+)</pattern>
+          <pattern operation="pattern match">^[^:]+:(?![!*])[^:\n]*:</pattern>
           <instance datatype="int">1</instance>
         </textfilecontent54_object>
       </objects>

--- a/gpos/xml/scap/ssg/content/ssg-chainguard-xccdf/OvalChecks/XccdfOvalChecks.xml
+++ b/gpos/xml/scap/ssg/content/ssg-chainguard-xccdf/OvalChecks/XccdfOvalChecks.xml
@@ -4626,7 +4626,7 @@
         code protection mechanisms are examples of privileged functions that require protection from
         non-privileged users. <html:pre>
           Script Verification:
-          To manually verify, run command 'cat /etc/shadow and verify that no additional users exist
+          To manually verify, run command 'cat /etc/shadow and verify that every entry's password field is locked ('!' or '*'), i.e. no login-capable users exist
         </html:pre>
       </description>
       <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
@@ -4639,7 +4639,7 @@
       <description> Setting the most restrictive default permissions ensures that when new accounts
         are created they do not have unnecessary access. <html:pre>
           Script Verification:
-          To manually verify, run command 'cat /etc/shadow and verify that no additional users exist
+          To manually verify, run command 'cat /etc/shadow and verify that every entry's password field is locked ('!' or '*'), i.e. no login-capable users exist
         </html:pre>
       </description>
       <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
@@ -4659,7 +4659,7 @@
         other than those accesses explicitly identified and documented by the organization when
         related to the use of anonymous access. <html:pre>
           Script Verification:
-          To manually verify, run command 'cat /etc/shadow and verify that no additional users exist
+          To manually verify, run command 'cat /etc/shadow and verify that every entry's password field is locked ('!' or '*'), i.e. no login-capable users exist
         </html:pre>
       </description>
       <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
@@ -4684,7 +4684,7 @@
         requirements, many operating systems can be integrated with enterprise-level
         authentication/access mechanisms that meet or exceed access control policy requirements. <html:pre>
         Script Verification:
-          To manually verify, run command 'cat /etc/shadow and verify that no additional users exist
+          To manually verify, run command 'cat /etc/shadow and verify that every entry's password field is locked ('!' or '*'), i.e. no login-capable users exist
         </html:pre>
       </description>
       <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
@@ -4709,7 +4709,7 @@
         system resources. This may include isolating the administrative interface on a different
         security domain and with additional access controls. <html:pre>
           Script Verification:
-          To manually verify, run command 'cat /etc/shadow and verify that no additional users exist
+          To manually verify, run command 'cat /etc/shadow and verify that every entry's password field is locked ('!' or '*'), i.e. no login-capable users exist
         </html:pre>
       </description>
       <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
@@ -4723,7 +4723,7 @@
         they do not have authorization. When operating systems provide the capability to change user
         authenticators, it is critical the user re-authenticate. <html:pre>
           Script Verification:
-          To manually verify, run command 'cat /etc/shadow and verify that no additional users exist
+          To manually verify, run command 'cat /etc/shadow and verify that every entry's password field is locked ('!' or '*'), i.e. no login-capable users exist
         </html:pre>
       </description>
       <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
@@ -4736,7 +4736,7 @@
         they do not have authorization. When operating systems provide the capability to change
         security roles, it is critical the user re-authenticate. <html:pre>
           Script Verification:
-          To manually verify, run command 'cat /etc/shadow and verify that no additional users exist
+          To manually verify, run command 'cat /etc/shadow and verify that every entry's password field is locked ('!' or '*'), i.e. no login-capable users exist
         </html:pre>
       </description>
       <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
@@ -4756,7 +4756,7 @@
         with enterprise-level authentication/access/auditing mechanisms that meet or exceed access
         control policy requirements. <html:pre>
           Script Verification:
-          To manually verify, run command 'cat /etc/shadow and verify that no additional users exist
+          To manually verify, run command 'cat /etc/shadow and verify that every entry's password field is locked ('!' or '*'), i.e. no login-capable users exist
         </html:pre>
       </description>
       <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
@@ -4776,7 +4776,7 @@
         enterprise-level authentication/access/auditing mechanisms that meet or exceed access
         control policy requirements. <html:pre>
           Script Verification:
-          To manually verify, run command 'cat /etc/shadow and verify that no additional users exist
+          To manually verify, run command 'cat /etc/shadow and verify that every entry's password field is locked ('!' or '*'), i.e. no login-capable users exist
         </html:pre>
       </description>
       <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
@@ -4799,7 +4799,7 @@
         accounts (e.g., shared privilege accounts) or for detailed accountability of individual
         activity. <html:pre>
           Script Verification:
-          To manually verify, run command 'cat /etc/shadow and verify that no additional users exist
+          To manually verify, run command 'cat /etc/shadow and verify that every entry's password field is locked ('!' or '*'), i.e. no login-capable users exist
         </html:pre>
       </description>
       <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
@@ -4817,7 +4817,7 @@
         operate at a higher privilege level and therefore should be excluded from the
         organization-defined software list after review. <html:pre>
           Script Verification:
-          To manually verify, run command 'cat /etc/shadow and verify that no additional users exist
+          To manually verify, run command 'cat /etc/shadow and verify that every entry's password field is locked ('!' or '*'), i.e. no login-capable users exist
         </html:pre>
       </description>
       <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
@@ -4848,7 +4848,7 @@
         access control require identity-based access control, that limitation is not required for
         this use of discretionary access control. <html:pre>
           Script Verification:
-          To manually verify, run command 'cat /etc/shadow and verify that no additional users exist
+          To manually verify, run command 'cat /etc/shadow and verify that every entry's password field is locked ('!' or '*'), i.e. no login-capable users exist
         </html:pre>
       </description>
       <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
@@ -4869,7 +4869,7 @@
         enterprise-level authentication/access mechanisms that meet or exceed access control policy
         requirements. <html:pre>
           Script Verification:
-          To manually verify, run command 'cat /etc/shadow and verify that no additional users exist
+          To manually verify, run command 'cat /etc/shadow and verify that every entry's password field is locked ('!' or '*'), i.e. no login-capable users exist
         </html:pre>
       </description>
       <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
@@ -4899,7 +4899,7 @@
         transferred; using the information system to monitor account usage; and using automated
         telephonic notification to report atypical system account usage. <html:pre>
           Script Verification:
-          To manually verify, run command 'cat /etc/shadow and verify that no additional users exist
+          To manually verify, run command 'cat /etc/shadow and verify that every entry's password field is locked ('!' or '*'), i.e. no login-capable users exist
         </html:pre>
       </description>
       <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
@@ -4913,7 +4913,7 @@
         Non-privileged users should coordinate any sharing of information with an SA through shared
         resources. <html:pre>
           Script Verification:
-          To manually verify, run command 'cat /etc/shadow and verify that no additional users exist
+          To manually verify, run command 'cat /etc/shadow and verify that every entry's password field is locked ('!' or '*'), i.e. no login-capable users exist
         </html:pre>
       </description>
       <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
@@ -4929,7 +4929,7 @@
         sufficient detail to reconstruct events to determine the actual account involved in the
         activity. <html:pre>
           Script Verification:
-          To manually verify, run command 'cat /etc/shadow and verify that no additional users exist
+          To manually verify, run command 'cat /etc/shadow and verify that every entry's password field is locked ('!' or '*'), i.e. no login-capable users exist
         </html:pre>
       </description>
       <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
@@ -4945,7 +4945,7 @@
         been obtained. Operating systems need to track periods of inactivity and disable application
         identifiers after 35 days of inactivity. <html:pre>
           Script Verification:
-          To manually verify, run command 'cat /etc/shadow and verify that no additional users exist
+          To manually verify, run command 'cat /etc/shadow and verify that every entry's password field is locked ('!' or '*'), i.e. no login-capable users exist
         </html:pre>
       </description>
       <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">

--- a/gpos/xml/scap/ssg/content/ssg-chainguard-xccdf/OvalDefinitions/NoUsersCheck.xml
+++ b/gpos/xml/scap/ssg/content/ssg-chainguard-xccdf/OvalDefinitions/NoUsersCheck.xml
@@ -7,44 +7,34 @@
     <oval:timestamp>2024-05-29T12:00:00</oval:timestamp>
   </generator>
   <definitions>
-    <definition id="oval:org.NoUsers:def:1" version="1" class="compliance">
+    <definition id="oval:org.NoUsers:def:1" version="2" class="compliance">
       <metadata>
-        <title>Check for Unauthorized Users in /etc/shadow</title>
-        <description>Ensure there are no unauthorized users in the /etc/shadow file below the 'nobody' line.</description>
+        <title>Check for Login-Capable Users in /etc/shadow</title>
+        <description>Ensure every entry in /etc/shadow is locked (password field starts with '!' or '*'), i.e. there are no login-capable user accounts. Locked service accounts, such as those apko creates for image run-as users, cannot log in and are permitted.</description>
         <reference source="Custom"/>
         <affected family="unix">
           <platform>Chainguard</platform>
         </affected>
       </metadata>
       <criteria operator="AND">
-        <criterion comment="Check that the 'nobody' line is present" test_ref="oval:org.NoUsers:tst:1"/>
-        <criterion comment="Check for unauthorized users after the 'nobody' line" test_ref="oval:org.NoUsers:tst:2"/>
+        <criterion comment="Check that no unlocked entries exist in /etc/shadow" test_ref="oval:org.NoUsers:tst:1"/>
       </criteria>
     </definition>
   </definitions>
   <tests>
-    <!-- Test to check the presence of 'nobody' line -->
-    <textfilecontent54_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" check="all" check_existence="at_least_one_exists" comment="Check presence of 'nobody' line in /etc/shadow" id="oval:org.NoUsers:tst:1" version="1">
+    <!-- Test that no entry has an unlocked (login-capable) password field -->
+    <textfilecontent54_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" check="all" check_existence="none_exist" comment="Check for unlocked entries in /etc/shadow" id="oval:org.NoUsers:tst:1" version="2">
       <object object_ref="oval:org.NoUsers:obj:1"/>
-    </textfilecontent54_test>
-    <!-- Test to check for any lines after 'nobody' -->
-    <textfilecontent54_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" check="all" check_existence="none_exist" comment="Check for unauthorized users after the 'nobody' line in /etc/shadow" id="oval:org.NoUsers:tst:2" version="1">
-      <object object_ref="oval:org.NoUsers:obj:2"/>
     </textfilecontent54_test>
   </tests>
   <objects>
-    <!-- Object to find the 'nobody' line -->
-    <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:org.NoUsers:obj:1" version="1">
+    <!-- Object matching any entry whose password field does not start with '!' or '*'.
+         This intentionally matches empty password fields (passwordless login) too.
+         Same pattern as UserPasswordConfiguredTest's oval:org.example:obj:6. -->
+    <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:org.NoUsers:obj:1" version="2">
       <path>/etc</path>
       <filename>shadow</filename>
-      <pattern operation="pattern match">^nobody:.*</pattern>
-      <instance datatype="int">1</instance>
-    </textfilecontent54_object>
-    <!-- Object to find any lines after 'nobody' -->
-    <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:org.NoUsers:obj:2" version="1">
-      <path>/etc</path>
-      <filename>shadow</filename>
-      <pattern operation="pattern match">^nobody:.*\n(.+)</pattern>
+      <pattern operation="pattern match">^[^:]+:(?![!*])[^:\n]*:</pattern>
       <instance datatype="int">1</instance>
     </textfilecontent54_object>
   </objects>

--- a/tests/oscap-offline/internal/scan/fixtures_test.go
+++ b/tests/oscap-offline/internal/scan/fixtures_test.go
@@ -320,10 +320,11 @@ var activeShadowEntry = []byte("compliance-test:ZZx/p0vU8jVbA:19000:0:99999:7:::
 // field, the case a hashed-password fixture never exercises.
 var emptyShadowPassword = []byte("emptyacct::19000:0:99999:7:::\n")
 
-// extraShadowUser is a line appended after the trailing `nobody:` entry, which
-// the NoUsers obj:2 pattern `^nobody:.*\n(.+)` matches, failing the none_exist
-// "no users after nobody" test.
-var extraShadowUser = []byte("intruder:!::0:::::\n")
+// lockedShadowUser is a locked ("!") entry appended after the trailing
+// `nobody:` line, mirroring what apko writes for image run-as users. The
+// NoUsers pattern `^[^:]+:(?![!*])[^:\n]*:` must NOT match it — locked
+// service accounts cannot log in and are permitted.
+var lockedShadowUser = []byte("nonroot:!::0:::::\n")
 
 // fipsModuleCnf, opensslCnf, and apkFIPSPackages together satisfy all seven
 // DetectOpenSsl criteria: the two config files must exist, both FIPS packages
@@ -456,15 +457,26 @@ func matrixCases() []matrixCase {
 			want: map[string]results.Result{ruleUserPasswordConfigured: results.Fail},
 		},
 
-		// NoUsers: clean base ends /etc/shadow with the `nobody:` line; nothing
-		// follows it.
+		// NoUsers: clean base has only locked entries in /etc/shadow.
 		{
 			name: "no_users/pass_clean",
 			want: map[string]results.Result{ruleNoUsers: results.Pass},
 		},
+		// A locked entry after `nobody` is what apko writes for run-as
+		// users; it cannot log in and must not fail the check.
 		{
-			name: "no_users/fail_extra_user",
-			ops:  []overlay.Op{overlay.AppendFile("etc/shadow", extraShadowUser)},
+			name: "no_users/pass_locked_extra_user",
+			ops:  []overlay.Op{overlay.AppendFile("etc/shadow", lockedShadowUser)},
+			want: map[string]results.Result{ruleNoUsers: results.Pass},
+		},
+		{
+			name: "no_users/fail_unlocked_user",
+			ops:  []overlay.Op{overlay.AppendFile("etc/shadow", activeShadowEntry)},
+			want: map[string]results.Result{ruleNoUsers: results.Fail},
+		},
+		{
+			name: "no_users/fail_empty_password_user",
+			ops:  []overlay.Op{overlay.AppendFile("etc/shadow", emptyShadowPassword)},
 			want: map[string]results.Result{ruleNoUsers: results.Fail},
 		},
 


### PR DESCRIPTION
apko now writes locked (!) /etc/shadow entries for the users it creates, per passwd(5). The NoUsers OVAL definition backing 18 GPOS rules required that nothing follow the nobody line in /etc/shadow, so every image with an apko-created run-as user now fails all 18 rules at once. Redefine the check to assert what those rules actually attest: no login-capable accounts exist, i.e. every entry's password field is locked with ! or *. Locked service accounts cannot log in and pass; hashed or empty password fields still fail. This makes the definition semantically equivalent to UserPasswordConfigured, but the two feed different XCCDF rule families, so both stay. Images built before and after the apko change both pass, so this can roll out ahead of any apko upgrade.