### PR TITLE
Accept SSL_CERT_FILE pointing at a /kaniko CA bundle copy

### DIFF
--- a/gpos/xml/scap/ssg/content/ssg-chainguard-gpos-ds.xml
+++ b/gpos/xml/scap/ssg/content/ssg-chainguard-gpos-ds.xml
@@ -6228,7 +6228,14 @@
                         sha256sum -c .ca-certificates.crt.sha256' so the bundle matches the digest
                         the package recorded for it, and that the SSL_CERT_FILE environment variable
                         configured on the image or container is set to
-                        /etc/ssl/certs/ca-certificates.crt. On Java-based images, which additionally
+                        /etc/ssl/certs/ca-certificates.crt. Images that carry a second copy of the
+                        bundle under /kaniko may instead point SSL_CERT_FILE at
+                        /kaniko/ssl/certs/ca-certificates.crt, provided that copy carries the digest
+                        recorded for it: run 'cd /kaniko/ssl/certs &amp;&amp; sha256sum -c
+                        .ca-certificates.crt.sha256' where a stamp file is shipped beside the copy,
+                        and otherwise check it against the system stamp file with 'cd
+                        /kaniko/ssl/certs &amp;&amp; sha256sum -c
+                        /etc/ssl/certs/.ca-certificates.crt.sha256'. On Java-based images, which additionally
                         ship a truststore at /etc/ssl/certs/java/cacerts, also run 'cd
                         /etc/ssl/certs/java &amp;&amp; sha256sum -c .cacerts.sha256'. Images with no
                         /etc/ssl/certs/java/cacerts have no truststore to verify.
@@ -6687,7 +6694,7 @@
         <definition id="oval:org.CABundleHash:def:1" version="1" class="compliance">
           <metadata>
             <title>Validate SHA-256 hash of CA bundle</title>
-            <description>Passes only if the CA bundle exists, its SHA-256 matches the digest recorded in the ca-certificates package stamp file /etc/ssl/certs/.ca-certificates.crt.sha256, and the SSL_CERT_FILE environment variable configured on the image or container is set to /etc/ssl/certs/ca-certificates.crt. Java images additionally ship a JKS/PKCS12 truststore at /etc/ssl/certs/java/cacerts; when that file is present it must likewise match the digest in /etc/ssl/certs/java/.cacerts.sha256. Images without Java carry no truststore and are unaffected.</description>
+            <description>Passes only if the CA bundle exists, its SHA-256 matches the digest recorded in the ca-certificates package stamp file /etc/ssl/certs/.ca-certificates.crt.sha256, and the SSL_CERT_FILE environment variable configured on the image or container is set to /etc/ssl/certs/ca-certificates.crt. Images that carry a second copy of the bundle at /kaniko/ssl/certs/ca-certificates.crt may point SSL_CERT_FILE there instead; that copy is then held to the digest in its own stamp file /kaniko/ssl/certs/.ca-certificates.crt.sha256 where the image ships one, and otherwise to the digest in the system stamp file. A stamp file beside the copy takes precedence, so it cannot be sidestepped by the system one, and an unverified or divergent copy cannot satisfy the rule. Java images additionally ship a JKS/PKCS12 truststore at /etc/ssl/certs/java/cacerts; when that file is present it must likewise match the digest in /etc/ssl/certs/java/.cacerts.sha256. Images without Java carry no truststore and are unaffected.</description>
             <affected family="unix">
               <platform>Chainguard</platform>
             </affected>
@@ -6696,7 +6703,23 @@
             <criterion test_ref="oval:org.CABundleHash:tst:1" comment="Ensure CA bundle file exists"/>
             <criterion test_ref="oval:org.CABundleHash:tst:4" comment="Ensure CA bundle checksum stamp file exists and is well formed"/>
             <criterion test_ref="oval:org.CABundleHash:tst:2" comment="Ensure CA bundle hash matches the checksum stamp file"/>
-            <criterion test_ref="oval:org.CABundleHash:tst:3" comment="Ensure SSL_CERT_FILE is set to the system CA bundle path"/>
+            <criteria operator="OR" comment="SSL_CERT_FILE names a copy of the CA bundle verified against a checksum stamp file">
+              <criterion test_ref="oval:org.CABundleHash:tst:3" comment="Ensure SSL_CERT_FILE is set to the system CA bundle path"/>
+              <criteria operator="AND" comment="Images carrying the bundle under /kaniko may point SSL_CERT_FILE at that copy">
+                <criterion test_ref="oval:org.CABundleHash:tst:8" comment="Ensure the /kaniko CA bundle copy exists"/>
+                <criteria operator="OR" comment="The /kaniko copy matches its own checksum stamp file where one is shipped beside it, otherwise the system one">
+                  <criteria operator="AND" comment="Stamp file shipped beside the /kaniko copy takes precedence">
+                    <criterion test_ref="oval:org.CABundleHash:tst:11" comment="Ensure the /kaniko checksum stamp file exists and is well formed"/>
+                    <criterion test_ref="oval:org.CABundleHash:tst:12" comment="Ensure the /kaniko CA bundle copy matches the /kaniko checksum stamp file"/>
+                  </criteria>
+                  <criteria operator="AND" comment="No stamp file beside the /kaniko copy, so fall back to the system one">
+                    <criterion test_ref="oval:org.CABundleHash:tst:13" comment="No checksum stamp file beside the /kaniko CA bundle copy"/>
+                    <criterion test_ref="oval:org.CABundleHash:tst:9" comment="Ensure the /kaniko CA bundle copy matches the system checksum stamp file"/>
+                  </criteria>
+                </criteria>
+                <criterion test_ref="oval:org.CABundleHash:tst:10" comment="Ensure SSL_CERT_FILE is set to the /kaniko CA bundle path"/>
+              </criteria>
+            </criteria>
             <criteria operator="OR" comment="Java truststore, where one is present, matches its checksum stamp file">
               <criterion test_ref="oval:org.CABundleHash:tst:5" comment="No Java truststore present (non-Java image)"/>
               <criteria operator="AND">
@@ -6732,6 +6755,27 @@
           <ind:object object_ref="oval:org.CABundleHash:obj:7"/>
           <ind:state state_ref="oval:org.CABundleHash:ste:3"/>
         </ind:filehash58_test>
+        <unix:file_test id="oval:org.CABundleHash:tst:8" version="1" check="all" check_existence="only_one_exists" comment="Ensure the /kaniko CA bundle copy exists">
+          <unix:object object_ref="oval:org.CABundleHash:obj:8"/>
+        </unix:file_test>
+        <ind:filehash58_test id="oval:org.CABundleHash:tst:9" version="1" check="all" check_existence="only_one_exists" comment="Check that the /kaniko CA bundle copy matches the SHA-256 recorded in the system ca-certificates checksum stamp file">
+          <ind:object object_ref="oval:org.CABundleHash:obj:9"/>
+          <ind:state state_ref="oval:org.CABundleHash:ste:1"/>
+        </ind:filehash58_test>
+        <ind:environmentvariable58_test id="oval:org.CABundleHash:tst:10" version="1" check="all" check_existence="all_exist" comment="SSL_CERT_FILE equals /kaniko/ssl/certs/ca-certificates.crt">
+          <ind:object object_ref="oval:org.CABundleHash:obj:3"/>
+          <ind:state state_ref="oval:org.CABundleHash:ste:4"/>
+        </ind:environmentvariable58_test>
+        <ind:textfilecontent54_test id="oval:org.CABundleHash:tst:11" version="1" check="all" check_existence="only_one_exists" comment="Checksum stamp file beside the /kaniko copy exists and contains a single SHA-256 digest for ca-certificates.crt">
+          <ind:object object_ref="oval:org.CABundleHash:obj:10"/>
+        </ind:textfilecontent54_test>
+        <ind:filehash58_test id="oval:org.CABundleHash:tst:12" version="1" check="all" check_existence="only_one_exists" comment="Check that the /kaniko CA bundle copy matches the SHA-256 recorded in the stamp file beside it">
+          <ind:object object_ref="oval:org.CABundleHash:obj:9"/>
+          <ind:state state_ref="oval:org.CABundleHash:ste:5"/>
+        </ind:filehash58_test>
+        <unix:file_test id="oval:org.CABundleHash:tst:13" version="1" check="all" check_existence="none_exist" comment="No checksum stamp file at /kaniko/ssl/certs/.ca-certificates.crt.sha256">
+          <unix:object object_ref="oval:org.CABundleHash:obj:11"/>
+        </unix:file_test>
       </tests>
       <objects>
         <unix:file_object id="oval:org.CABundleHash:obj:1" version="1">
@@ -6764,6 +6808,22 @@
           <ind:filepath>/etc/ssl/certs/java/cacerts</ind:filepath>
           <ind:hash_type>SHA-256</ind:hash_type>
         </ind:filehash58_object>
+        <unix:file_object id="oval:org.CABundleHash:obj:8" version="1" comment="CA bundle copy, present only in images that carry one under /kaniko">
+          <unix:filepath>/kaniko/ssl/certs/ca-certificates.crt</unix:filepath>
+        </unix:file_object>
+        <ind:filehash58_object id="oval:org.CABundleHash:obj:9" version="1">
+          <ind:filepath>/kaniko/ssl/certs/ca-certificates.crt</ind:filepath>
+          <ind:hash_type>SHA-256</ind:hash_type>
+        </ind:filehash58_object>
+        <ind:textfilecontent54_object id="oval:org.CABundleHash:obj:10" version="1" comment="SHA-256 digest recorded beside the /kaniko CA bundle copy, where the image ships one">
+          <ind:path>/kaniko/ssl/certs</ind:path>
+          <ind:filename>.ca-certificates.crt.sha256</ind:filename>
+          <ind:pattern operation="pattern match">^([0-9a-fA-F]{64})[ \t]+\*?ca-certificates\.crt$</ind:pattern>
+          <ind:instance datatype="int">1</ind:instance>
+        </ind:textfilecontent54_object>
+        <unix:file_object id="oval:org.CABundleHash:obj:11" version="1" comment="Stamp file beside the /kaniko copy, as a file so its absence is distinguishable from it being unparseable">
+          <unix:filepath>/kaniko/ssl/certs/.ca-certificates.crt.sha256</unix:filepath>
+        </unix:file_object>
       </objects>
       <states>
         <ind:filehash58_state id="oval:org.CABundleHash:ste:1" version="1">
@@ -6777,6 +6837,13 @@
           <ind:hash_type>SHA-256</ind:hash_type>
           <ind:hash datatype="string" operation="case insensitive equals" var_ref="oval:org.CABundleHash:var:2" var_check="all"/>
         </ind:filehash58_state>
+        <ind:environmentvariable58_state id="oval:org.CABundleHash:ste:4" version="1">
+          <ind:value datatype="string" operation="equals">/kaniko/ssl/certs/ca-certificates.crt</ind:value>
+        </ind:environmentvariable58_state>
+        <ind:filehash58_state id="oval:org.CABundleHash:ste:5" version="1">
+          <ind:hash_type>SHA-256</ind:hash_type>
+          <ind:hash datatype="string" operation="case insensitive equals" var_ref="oval:org.CABundleHash:var:3" var_check="all"/>
+        </ind:filehash58_state>
       </states>
       <variables>
         <local_variable id="oval:org.CABundleHash:var:1" version="1" datatype="string" comment="Expected CA bundle SHA-256, read from /etc/ssl/certs/.ca-certificates.crt.sha256">
@@ -6784,6 +6851,9 @@
         </local_variable>
         <local_variable id="oval:org.CABundleHash:var:2" version="1" datatype="string" comment="Expected Java truststore SHA-256, read from /etc/ssl/certs/java/.cacerts.sha256">
           <object_component object_ref="oval:org.CABundleHash:obj:6" item_field="subexpression"/>
+        </local_variable>
+        <local_variable id="oval:org.CABundleHash:var:3" version="1" datatype="string" comment="Expected /kaniko CA bundle SHA-256, read from /kaniko/ssl/certs/.ca-certificates.crt.sha256 where the image ships one">
+          <object_component object_ref="oval:org.CABundleHash:obj:10" item_field="subexpression"/>
         </local_variable>
       </variables>
     </oval_definitions>

--- a/tests/e2e/fixtures/cabundle-kaniko/Dockerfile
+++ b/tests/e2e/fixtures/cabundle-kaniko/Dockerfile
@@ -1,0 +1,28 @@
+# Copyright 2026 Chainguard, Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# CertificateAudit kaniko-layout fixture.
+#
+# Mirrors the trust store layout cgr.dev/chainguard/kaniko ships: the CA bundle
+# is copied to /kaniko/ssl/certs/ca-certificates.crt and SSL_CERT_FILE names
+# that copy instead of /etc/ssl/certs/ca-certificates.crt. No stamp file is
+# copied alongside it, because the kaniko image ships none there either.
+#
+# CertificateAudit accepts the alternative location only when the copy carries
+# the digest the ca-certificates stamp file at /etc/ssl/certs records, which an
+# untouched copy does. The rule must therefore PASS.
+FROM cgr.dev/chainguard/wolfi-base:latest@sha256:07e60ff6586b56f03c625e27b604f9f7d29498fef32f099f6560f0d207b4a056
+
+# Suppress OrbStack's automatic root-CA injection so the bundle (and the copy
+# taken from it) is identical to the upstream wolfi-base bundle the stamp file
+# describes. Without this, the CertificateAudit SHA-256 check would fail on
+# macOS/OrbStack hosts.
+# See https://docs.orbstack.dev/features/https.
+LABEL dev.orbstack.add-ca-certificates=false
+
+USER root
+
+RUN mkdir -p /kaniko/ssl/certs \
+      && cp /etc/ssl/certs/ca-certificates.crt /kaniko/ssl/certs/ca-certificates.crt
+
+ENV SSL_CERT_FILE=/kaniko/ssl/certs/ca-certificates.crt

--- a/tests/e2e/fixtures/cabundle-kaniko/expected.txt
+++ b/tests/e2e/fixtures/cabundle-kaniko/expected.txt
@@ -1,0 +1,7 @@
+# Fixture: cabundle-kaniko
+#
+# The CA bundle is carried at /kaniko/ssl/certs/ca-certificates.crt and
+# SSL_CERT_FILE names it, the layout cgr.dev/chainguard/kaniko ships. That copy
+# still matches the digest recorded in /etc/ssl/certs/.ca-certificates.crt.sha256,
+# so CertificateAudit must PASS.
+xccdf_mil.disa.stig_rule_SV-263659r982563_rule=pass

--- a/tests/oscap-offline/internal/overlay/doc.go
+++ b/tests/oscap-offline/internal/overlay/doc.go
@@ -2,10 +2,10 @@
 // filesystem tar, producing a deterministic fixture tar.
 //
 // Each transform is an Op constructed by one of the exported helpers
-// (AppendFile, AddFile, Chown). Apply reads a base tar, applies the ops in
-// declaration order, and writes a PAX-format tar containing the surviving base
-// entries in their original order followed by any added entries in
-// op-declaration order.
+// (AppendFile, AddFile, CopyFile, Chown). Apply reads a base tar, applies the
+// ops in declaration order, and writes a PAX-format tar containing the
+// surviving base entries in their original order followed by any added entries
+// in op-declaration order.
 //
 // Ownership and permissions are written directly into the tar headers, so the
 // resulting uid, gid and mode of every entry are determined entirely by the
@@ -13,10 +13,11 @@
 // process. Declaring root ownership (uid 0, gid 0) yields a root-owned header
 // even when the harness runs unprivileged.
 //
-// Ops that target a missing path (AppendFile, Chown) or that add an
-// already-present path (AddFile) cause Apply to return a wrapped ErrNotFound or
-// ErrExists; AppendFile additionally returns a wrapped ErrNotRegular when its
-// target is not a regular file. Callers should match with errors.Is.
+// Ops that target a missing path (AppendFile, CopyFile's source, Chown) or that
+// add an already-present path (AddFile, CopyFile's destination) cause Apply to
+// return a wrapped ErrNotFound or ErrExists; AppendFile and CopyFile
+// additionally return a wrapped ErrNotRegular when the entry whose content they
+// read is not a regular file. Callers should match with errors.Is.
 //
 // Every base member and every added path must be a clean, local, relative path
 // with no NUL byte; a member that is absolute or contains ".." causes Apply to

--- a/tests/oscap-offline/internal/overlay/overlay.go
+++ b/tests/oscap-offline/internal/overlay/overlay.go
@@ -141,6 +141,23 @@ func AddFile(path string, content []byte, mode int64, uid, gid int) Op {
 	}
 }
 
+// CopyFile adds a new regular-file entry at dst holding a copy of src's
+// content, mode and ownership, letting a fixture reproduce a base file at a
+// second path (e.g. the CA bundle a kaniko image carries under /kaniko) without
+// restating its bytes. src must exist and be a regular file, otherwise Apply
+// returns a wrapped ErrNotFound or ErrNotRegular; dst must not already exist,
+// otherwise it returns a wrapped ErrExists. The copy is taken when the op runs,
+// so an earlier op that mutates src is reflected in dst.
+func CopyFile(src, dst string) Op {
+	return func(p *plan) {
+		e := p.requireReg(src)
+		if e == nil {
+			return
+		}
+		AddFile(dst, e.data, e.hdr.Mode, e.hdr.Uid, e.hdr.Gid)(p)
+	}
+}
+
 // Chown changes only the uid and gid of an existing entry. The path must exist,
 // otherwise Apply returns a wrapped ErrNotFound.
 func Chown(path string, uid, gid int) Op {

--- a/tests/oscap-offline/internal/overlay/overlay_test.go
+++ b/tests/oscap-offline/internal/overlay/overlay_test.go
@@ -163,6 +163,52 @@ func TestAppendFileRejectsNonRegular(t *testing.T) {
 	}
 }
 
+// TestCopyFile proves the destination reproduces the source's content, mode and
+// ownership byte for byte, that the source survives untouched, and that the copy
+// reflects an earlier op that mutated the source (ops run in declaration order).
+func TestCopyFile(t *testing.T) {
+	t.Parallel()
+
+	content := randBytes(48)
+	extra := randBytes(16)
+	base := buildTar(t, map[string]fileSpec{
+		"etc/bundle": {content: content, mode: 0o600, uid: 11, gid: 13},
+	})
+
+	got := apply(t, base,
+		AppendFile("etc/bundle", extra),
+		CopyFile("etc/bundle", "kaniko/bundle"),
+	)
+	order, byName := readEntries(t, got)
+
+	want := fileSpec{content: append(append([]byte{}, content...), extra...), mode: 0o600, uid: 11, gid: 13}
+	if diff := cmp.Diff(want, byName["kaniko/bundle"], cmp.AllowUnexported(fileSpec{})); diff != "" {
+		t.Errorf("copy mismatch (-want,+got):\n%s", diff)
+	}
+	if diff := cmp.Diff(want, byName["etc/bundle"], cmp.AllowUnexported(fileSpec{})); diff != "" {
+		t.Errorf("source mutated by copy (-want,+got):\n%s", diff)
+	}
+	if diff := cmp.Diff([]string{"etc/bundle", "kaniko/bundle"}, order); diff != "" {
+		t.Errorf("order mismatch (-want,+got):\n%s", diff)
+	}
+}
+
+// TestCopyFileRejectsNonRegular proves CopyFile reading a base member that is
+// not a regular file (here a directory) returns a wrapped ErrNotRegular, the
+// same failure mode AppendFile has, rather than producing a bogus entry.
+func TestCopyFileRejectsNonRegular(t *testing.T) {
+	t.Parallel()
+
+	base := buildRawTar(t,
+		tar.Header{Name: "etc/", Typeflag: tar.TypeDir, Mode: 0o755},
+	)
+	var out bytes.Buffer
+	err := Apply(bytes.NewReader(base), []Op{CopyFile("etc/", "kaniko/etc")}, &out)
+	if !errors.Is(err, ErrNotRegular) {
+		t.Fatalf("Apply error = %v, want errors.Is ErrNotRegular", err)
+	}
+}
+
 func TestReplaceFile(t *testing.T) {
 	t.Parallel()
 
@@ -315,6 +361,8 @@ func TestApplyErrors(t *testing.T) {
 		{"append missing path", AppendFile("etc/absent", []byte("y"))},
 		{"chown missing path", Chown("etc/absent", 1, 1)},
 		{"add existing path", AddFile("etc/present", []byte("y"), 0o644, 0, 0)},
+		{"copy missing source", CopyFile("etc/absent", "etc/copy")},
+		{"copy onto existing path", CopyFile("etc/present", "etc/present")},
 	}
 
 	for _, tt := range tests {

--- a/tests/oscap-offline/internal/scan/fixtures_test.go
+++ b/tests/oscap-offline/internal/scan/fixtures_test.go
@@ -314,6 +314,17 @@ var caTamper = []byte("\n# tamper\n-----BEGIN CERTIFICATE-----\nTAMPERED\n-----E
 // it instead of pinning one in the datastream.
 const caStampPath = "etc/ssl/certs/.ca-certificates.crt.sha256"
 
+// caBundlePath and kanikoCABundlePath are the two locations CertificateAudit
+// accepts SSL_CERT_FILE pointing at, as tar member paths (rootfs-relative, no
+// leading slash). kanikoCAStampPath is the stamp file the /kaniko copy is
+// checked against where one is shipped beside it; cgr.dev/chainguard/kaniko
+// ships none today, so the copy falls back to the stamp at caStampPath.
+const (
+	caBundlePath       = "etc/ssl/certs/ca-certificates.crt"
+	kanikoCABundlePath = "kaniko/ssl/certs/ca-certificates.crt"
+	kanikoCAStampPath  = "kaniko/ssl/certs/.ca-certificates.crt.sha256"
+)
+
 // caStampWrongDigest is a well-formed stamp naming a digest the untouched
 // bundle cannot have (all zeroes), isolating the comparison from the stamp
 // side: the bundle is clean, the expected value is not.
@@ -447,13 +458,13 @@ func matrixCases() []matrixCase {
 
 		// CertificateAudit is an AND of five criteria: the CA bundle exists, the
 		// ca-certificates stamp file exists and yields one SHA-256 digest, the
-		// bundle's SHA-256 equals that digest, SSL_CERT_FILE is set to the
-		// bundle path, and — only where /etc/ssl/certs/java/cacerts exists — the
-		// Java truststore likewise matches its own stamp file. Nothing here
-		// depends on a hash pinned in the datastream, so no fixture needs to move
-		// when an upstream bundle rolls. The pass fixture also sets
-		// SSL_CERT_FILE; the fail fixtures each isolate one failing dimension
-		// while holding the others valid.
+		// bundle's SHA-256 equals that digest, SSL_CERT_FILE names a copy of the
+		// bundle carrying that same digest, and — only where
+		// /etc/ssl/certs/java/cacerts exists — the Java truststore likewise
+		// matches its own stamp file. Nothing here depends on a hash pinned in
+		// the datastream, so no fixture needs to move when an upstream bundle
+		// rolls. The pass fixtures also set SSL_CERT_FILE; the fail fixtures each
+		// isolate one failing dimension while holding the others valid.
 		{
 			name:          "certificate_audit/pass_clean",
 			containerVars: []string{"SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt"},
@@ -462,7 +473,7 @@ func matrixCases() []matrixCase {
 		{
 			// Hash dimension: tampered bundle, SSL_CERT_FILE still valid.
 			name:          "certificate_audit/fail_tampered_bundle",
-			ops:           []overlay.Op{overlay.AppendFile("etc/ssl/certs/ca-certificates.crt", caTamper)},
+			ops:           []overlay.Op{overlay.AppendFile(caBundlePath, caTamper)},
 			containerVars: []string{"SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt"},
 			want:          map[string]results.Result{ruleCertificateAudit: results.Fail},
 		},
@@ -523,6 +534,79 @@ func matrixCases() []matrixCase {
 				overlay.AddFile(javaTrustStorePath, javaTrustStore, 0o444, 0, 0),
 			},
 			containerVars: []string{"SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt"},
+			want:          map[string]results.Result{ruleCertificateAudit: results.Fail},
+		},
+		{
+			// Kaniko fallback branch: the bundle is copied to the /kaniko location
+			// and SSL_CERT_FILE names that copy, the layout
+			// cgr.dev/chainguard/kaniko ships. No stamp file sits beside the copy,
+			// so it is held to the digest in the system stamp at /etc/ssl/certs,
+			// which it matches.
+			name:          "certificate_audit/pass_kaniko_bundle",
+			ops:           []overlay.Op{overlay.CopyFile(caBundlePath, kanikoCABundlePath)},
+			containerVars: []string{"SSL_CERT_FILE=/kaniko/ssl/certs/ca-certificates.crt"},
+			want:          map[string]results.Result{ruleCertificateAudit: results.Pass},
+		},
+		{
+			// Kaniko own-stamp branch: a stamp shipped beside the copy is what the
+			// copy is checked against. The system stamp records the same digest
+			// here, so this case proves the branch is reachable, not merely that
+			// the fallback still fires — fail_kaniko_own_stamp_wrong_digest below
+			// separates the two.
+			name: "certificate_audit/pass_kaniko_own_stamp",
+			ops: []overlay.Op{
+				overlay.CopyFile(caBundlePath, kanikoCABundlePath),
+				overlay.CopyFile(caStampPath, kanikoCAStampPath),
+			},
+			containerVars: []string{"SSL_CERT_FILE=/kaniko/ssl/certs/ca-certificates.crt"},
+			want:          map[string]results.Result{ruleCertificateAudit: results.Pass},
+		},
+		{
+			// Precedence: an untouched copy beside a stamp naming a digest it
+			// cannot have. The system stamp would match, so the rule may only fail
+			// if the stamp beside the copy takes priority over it rather than the
+			// two being OR'd.
+			name: "certificate_audit/fail_kaniko_own_stamp_wrong_digest",
+			ops: []overlay.Op{
+				overlay.CopyFile(caBundlePath, kanikoCABundlePath),
+				overlay.CopyFile(caStampPath, kanikoCAStampPath),
+				overlay.ReplaceFile(kanikoCAStampPath, caStampWrongDigest),
+			},
+			containerVars: []string{"SSL_CERT_FILE=/kaniko/ssl/certs/ca-certificates.crt"},
+			want:          map[string]results.Result{ruleCertificateAudit: results.Fail},
+		},
+		{
+			// Precedence, unparseable variant: a stamp beside the copy that yields
+			// no digest is a present stamp, not an absent one, so the fallback must
+			// not rescue it. This is the case a "no digest collected" test would
+			// conflate with the file being missing.
+			name: "certificate_audit/fail_kaniko_malformed_own_stamp",
+			ops: []overlay.Op{
+				overlay.CopyFile(caBundlePath, kanikoCABundlePath),
+				overlay.CopyFile(caStampPath, kanikoCAStampPath),
+				overlay.ReplaceFile(kanikoCAStampPath, caStampMalformed),
+			},
+			containerVars: []string{"SSL_CERT_FILE=/kaniko/ssl/certs/ca-certificates.crt"},
+			want:          map[string]results.Result{ruleCertificateAudit: results.Fail},
+		},
+		{
+			// Hash dimension on the /kaniko copy: the copy diverges from the digest
+			// the system stamp records while the /etc bundle stays clean. Accepting
+			// the alternative location must not mean accepting it unverified.
+			name: "certificate_audit/fail_kaniko_tampered_bundle",
+			ops: []overlay.Op{
+				overlay.CopyFile(caBundlePath, kanikoCABundlePath),
+				overlay.AppendFile(kanikoCABundlePath, caTamper),
+			},
+			containerVars: []string{"SSL_CERT_FILE=/kaniko/ssl/certs/ca-certificates.crt"},
+			want:          map[string]results.Result{ruleCertificateAudit: results.Fail},
+		},
+		{
+			// Existence dimension on the /kaniko copy: SSL_CERT_FILE names it but no
+			// such file was laid down, so naming an accepted path is not on its own
+			// enough to pass.
+			name:          "certificate_audit/fail_kaniko_env_without_bundle",
+			containerVars: []string{"SSL_CERT_FILE=/kaniko/ssl/certs/ca-certificates.crt"},
 			want:          map[string]results.Result{ruleCertificateAudit: results.Fail},
 		},
 		{


### PR DESCRIPTION
## Problem

`cgr.dev/chainguard/kaniko` carries a copy of the CA bundle at `/kaniko/ssl/certs/ca-certificates.crt` and sets `SSL_CERT_FILE` to it:

```
$ crane config cgr.dev/chainguard-private/kaniko:latest | jq -r '.config.Env[]'
...
SSL_CERT_FILE=/kaniko/ssl/certs/ca-certificates.crt
```

CertificateAudit only accepted `/etc/ssl/certs/ca-certificates.crt`, so the rule failed the image on its `SSL_CERT_FILE` criterion even though the copy is byte-identical to the packaged bundle.

## Change

`tst:3` becomes an OR, so `SSL_CERT_FILE` may name either location — but the alternative is accepted only as a whole, never as a bare string match:

```
AND: /etc bundle exists · /etc stamp well-formed · /etc bundle hash == /etc stamp
     OR:  SSL_CERT_FILE == /etc/ssl/certs/ca-certificates.crt                    (tst:3)
          AND: /kaniko copy exists                                               (tst:8)
               OR:  AND: /kaniko stamp exists & well-formed                      (tst:11)
                         /kaniko copy hash == /kaniko stamp digest               (tst:12)
                    AND: no /kaniko stamp file                                   (tst:13)
                         /kaniko copy hash == /etc stamp digest                  (tst:9)
               SSL_CERT_FILE == /kaniko/...                                      (tst:10)
     OR:  Java truststore branch, unchanged
```

A stamp file shipped beside the copy is authoritative where there is one; otherwise the copy falls back to the system stamp at `/etc/ssl/certs/.ca-certificates.crt.sha256` — the layout kaniko ships today, which has the copy but no stamp beside it.

The fallback arm is gated on `tst:13`, a `unix:file_test` with `check_existence="none_exist"`, rather than on the parse test failing. That is what makes it precedence rather than an OR of two acceptable digests: when a stamp sits beside the copy it is the only digest that counts. It also keeps "no stamp shipped" distinct from "stamp shipped but unparseable" — the latter fails instead of silently falling back.

The bundle and stamp criteria under `/etc` stay mandatory for every image: that stamp is the only digest source a copy shipped without one can be checked against.

## Tests

Six new offline fixtures, all run against real openscap:

| fixture | verdict | dimension |
| --- | --- | --- |
| `pass_kaniko_bundle` | pass | fallback arm — copy, no stamp beside it (what kaniko ships) |
| `pass_kaniko_own_stamp` | pass | own-stamp arm is reachable |
| `fail_kaniko_own_stamp_wrong_digest` | fail | **precedence** — the system stamp would have matched, so this fails only because the local stamp wins |
| `fail_kaniko_malformed_own_stamp` | fail | unparseable stamp beside the copy is a present stamp, not an absent one |
| `fail_kaniko_tampered_bundle` | fail | copy diverges from the system stamp |
| `fail_kaniko_env_without_bundle` | fail | naming an accepted path is not enough on its own |

Plus a `cabundle-kaniko` e2e fixture mirroring the real image's layout, and `overlay.CopyFile`, which lets a fixture reproduce a base file at a second path without restating its bytes (with unit tests).

Verified locally: all 16 `certificate_audit` offline fixtures pass, full `make test-offline` green, `cabundle-kaniko` / `baseline-clean` / `cabundle-tampered` e2e fixtures pass, `golangci-lint` clean. `make validate_xml` still fails, with an error set byte-identical to `main` — those schematron errors are pre-existing and noted in the Makefile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)