### PR TITLE
Add openssh-sftp-server to the datastream's remote-access ban list

### DIFF
--- a/gpos/xml/scap/ssg/content/ssg-chainguard-gpos-ds.xml
+++ b/gpos/xml/scap/ssg/content/ssg-chainguard-gpos-ds.xml
@@ -4017,7 +4017,7 @@
                             Script Verification:
                             To manually verify, Ensure none of the following remote access packages
                         exist in the folder /usr/lib/apk/db/ Packages:
-                            openssh, openssh-server, dropbear,
+                            openssh, openssh-server, openssh-sftp-server, dropbear,
                         tigervnc, tigervnc-server, tigervnc-viewer,
                             xrdp, xorgxrdp, vsftpd, proftpd, webmin, cockpit, cockpit-ws,
                         cockpit-bridge, nfs-utils, samba, samba-server, samba-client, samba-common,
@@ -4052,7 +4052,7 @@
                             Script Verification:
                             To manually verify, Ensure none of the following remote access packages
                         exist in the folder /usr/lib/apk/db/ Packages:
-                            openssh, openssh-server, dropbear,
+                            openssh, openssh-server, openssh-sftp-server, dropbear,
                         tigervnc, tigervnc-server, tigervnc-viewer,
                             xrdp, xorgxrdp, vsftpd, proftpd, webmin, cockpit, cockpit-ws,
                         cockpit-bridge, nfs-utils, samba, samba-server, samba-client, samba-common,
@@ -4087,7 +4087,7 @@
                         Script Verification:
                             To manually verify, Ensure none of the following remote access packages
                         exist in the folder /usr/lib/apk/db/ Packages:
-                            openssh, openssh-server, dropbear,
+                            openssh, openssh-server, openssh-sftp-server, dropbear,
                         tigervnc, tigervnc-server, tigervnc-viewer,
                             xrdp, xorgxrdp, vsftpd, proftpd, webmin, cockpit, cockpit-ws,
                         cockpit-bridge, nfs-utils, samba, samba-server, samba-client, samba-common,
@@ -4122,7 +4122,7 @@
                             Script Verification:
                             To manually verify, Ensure none of the following remote access packages
                         exist in the folder /usr/lib/apk/db/ Packages:
-                            openssh, openssh-server, dropbear,
+                            openssh, openssh-server, openssh-sftp-server, dropbear,
                         tigervnc, tigervnc-server, tigervnc-viewer,
                             xrdp, xorgxrdp, vsftpd, proftpd, webmin, cockpit, cockpit-ws,
                         cockpit-bridge, nfs-utils, samba, samba-server, samba-client, samba-common,
@@ -4151,7 +4151,7 @@
                             Script Verification:
                             To manually verify, Ensure none of the following remote access packages
                         exist in the folder /usr/lib/apk/db/ Packages:
-                            openssh, openssh-server, dropbear,
+                            openssh, openssh-server, openssh-sftp-server, dropbear,
                         tigervnc, tigervnc-server, tigervnc-viewer,
                             xrdp, xorgxrdp, vsftpd, proftpd, webmin, cockpit, cockpit-ws,
                         cockpit-bridge, nfs-utils, samba, samba-server, samba-client, samba-common,
@@ -4179,7 +4179,7 @@
                         Script Verification:
                             To manually verify, Ensure none of the following remote access packages
                         exist in the folder /usr/lib/apk/db/ Packages:
-                            openssh, openssh-server, dropbear,
+                            openssh, openssh-server, openssh-sftp-server, dropbear,
                         tigervnc, tigervnc-server, tigervnc-viewer,
                             xrdp, xorgxrdp, vsftpd, proftpd, webmin, cockpit, cockpit-ws,
                         cockpit-bridge, nfs-utils, samba, samba-server, samba-client, samba-common,
@@ -4199,7 +4199,7 @@
                         Script Verification:
                             To manually verify, Ensure none of the following remote access packages
                         exist in the folder /usr/lib/apk/db/ Packages:
-                            openssh, openssh-server, dropbear,
+                            openssh, openssh-server, openssh-sftp-server, dropbear,
                         tigervnc, tigervnc-server, tigervnc-viewer,
                             xrdp, xorgxrdp, vsftpd, proftpd, webmin, cockpit, cockpit-ws,
                         cockpit-bridge, nfs-utils, samba, samba-server, samba-client, samba-common,
@@ -4225,7 +4225,7 @@
                         Script Verification:
                             To manually verify, Ensure none of the following remote access packages
                         exist in the folder /usr/lib/apk/db/ Packages:
-                            openssh, openssh-server, dropbear,
+                            openssh, openssh-server, openssh-sftp-server, dropbear,
                         tigervnc, tigervnc-server, tigervnc-viewer,
                             xrdp, xorgxrdp, vsftpd, proftpd, webmin, cockpit, cockpit-ws,
                         cockpit-bridge, nfs-utils, samba, samba-server, samba-client, samba-common,
@@ -4256,7 +4256,7 @@
                             Script Verification:
                             To manually verify, Ensure none of the following remote access packages
                         exist in the folder /usr/lib/apk/db/ Packages:
-                            openssh, openssh-server, dropbear,
+                            openssh, openssh-server, openssh-sftp-server, dropbear,
                         tigervnc, tigervnc-server, tigervnc-viewer,
                             xrdp, xorgxrdp, vsftpd, proftpd, webmin, cockpit, cockpit-ws,
                         cockpit-bridge, nfs-utils, samba, samba-server, samba-client, samba-common,
@@ -4280,7 +4280,7 @@
                         Script Verification:
                             To manually verify, Ensure none of the following remote access packages
                         exist in the folder /usr/lib/apk/db/ Packages:
-                            openssh, openssh-server, dropbear,
+                            openssh, openssh-server, openssh-sftp-server, dropbear,
                         tigervnc, tigervnc-server, tigervnc-viewer,
                             xrdp, xorgxrdp, vsftpd, proftpd, webmin, cockpit, cockpit-ws,
                         cockpit-bridge, nfs-utils, samba, samba-server, samba-client, samba-common,
@@ -4303,7 +4303,7 @@
                             Script Verification:
                             To manually verify, Ensure none of the following remote access packages
                         exist in the folder /usr/lib/apk/db/ Packages:
-                            openssh, openssh-server, dropbear,
+                            openssh, openssh-server, openssh-sftp-server, dropbear,
                         tigervnc, tigervnc-server, tigervnc-viewer,
                             xrdp, xorgxrdp, vsftpd, proftpd, webmin, cockpit, cockpit-ws,
                         cockpit-bridge, nfs-utils, samba, samba-server, samba-client, samba-common,
@@ -4337,7 +4337,7 @@
                             Script Verification:
                             To manually verify, Ensure none of the following remote access packages
                         exist in the folder /usr/lib/apk/db/ Packages:
-                            openssh, openssh-server, dropbear,
+                            openssh, openssh-server, openssh-sftp-server, dropbear,
                         tigervnc, tigervnc-server, tigervnc-viewer,
                             xrdp, xorgxrdp, vsftpd, proftpd, webmin, cockpit, cockpit-ws,
                         cockpit-bridge, nfs-utils, samba, samba-server, samba-client, samba-common,
@@ -4372,7 +4372,7 @@
                         Script Verification:
                             To manually verify, Ensure none of the following remote access packages
                         exist in the folder /usr/lib/apk/db/ Packages:
-                            openssh, openssh-server, dropbear,
+                            openssh, openssh-server, openssh-sftp-server, dropbear,
                         tigervnc, tigervnc-server, tigervnc-viewer,
                             xrdp, xorgxrdp, vsftpd, proftpd, webmin, cockpit, cockpit-ws,
                         cockpit-bridge, nfs-utils, samba, samba-server, samba-client, samba-common,
@@ -4394,7 +4394,7 @@
                             Script Verification:
                             To manually verify, Ensure none of the following remote access packages
                         exist in the folder /usr/lib/apk/db/ Packages:
-                            openssh, openssh-server, dropbear,
+                            openssh, openssh-server, openssh-sftp-server, dropbear,
                         tigervnc, tigervnc-server, tigervnc-viewer,
                             xrdp, xorgxrdp, vsftpd, proftpd, webmin, cockpit, cockpit-ws,
                         cockpit-bridge, nfs-utils, samba, samba-server, samba-client, samba-common,
@@ -4431,7 +4431,7 @@
                             Script Verification:
                             To manually verify, Ensure none of the following remote access packages
                         exist in the folder /usr/lib/apk/db/ Packages:
-                            openssh, openssh-server, dropbear,
+                            openssh, openssh-server, openssh-sftp-server, dropbear,
                         tigervnc, tigervnc-server, tigervnc-viewer,
                             xrdp, xorgxrdp, vsftpd, proftpd, webmin, cockpit, cockpit-ws,
                         cockpit-bridge, nfs-utils, samba, samba-server, samba-client, samba-common,
@@ -4455,7 +4455,7 @@
                             Script Verification:
                             To manually verify, Ensure none of the following remote access packages
                         exist in the folder /usr/lib/apk/db/ Packages:
-                            openssh, openssh-server, dropbear,
+                            openssh, openssh-server, openssh-sftp-server, dropbear,
                         tigervnc, tigervnc-server, tigervnc-viewer,
                             xrdp, xorgxrdp, vsftpd, proftpd, webmin, cockpit, cockpit-ws,
                         cockpit-bridge, nfs-utils, samba, samba-server, samba-client, samba-common,
@@ -4479,7 +4479,7 @@
                             Script Verification:
                             To manually verify, Ensure none of the following remote access packages
                         exist in the folder /usr/lib/apk/db/ Packages:
-                            openssh, openssh-server, dropbear,
+                            openssh, openssh-server, openssh-sftp-server, dropbear,
                         tigervnc, tigervnc-server, tigervnc-viewer,
                             xrdp, xorgxrdp, vsftpd, proftpd, webmin, cockpit, cockpit-ws,
                         cockpit-bridge, nfs-utils, samba, samba-server, samba-client, samba-common,
@@ -4500,7 +4500,7 @@
                         Script Verification:
                             To manually verify, Ensure none of the following remote access packages
                         exist in the folder /usr/lib/apk/db/ Packages:
-                            openssh, openssh-server, dropbear,
+                            openssh, openssh-server, openssh-sftp-server, dropbear,
                         tigervnc, tigervnc-server, tigervnc-viewer,
                             xrdp, xorgxrdp, vsftpd, proftpd, webmin, cockpit, cockpit-ws,
                         cockpit-bridge, nfs-utils, samba, samba-server, samba-client, samba-common,
@@ -4537,7 +4537,7 @@
                             Script Verification:
                             To manually verify, Ensure none of the following remote access packages
                         exist in the folder /usr/lib/apk/db/ Packages:
-                            openssh, openssh-server, dropbear,
+                            openssh, openssh-server, openssh-sftp-server, dropbear,
                         tigervnc, tigervnc-server, tigervnc-viewer,
                             xrdp, xorgxrdp, vsftpd, proftpd, webmin, cockpit, cockpit-ws,
                         cockpit-bridge, nfs-utils, samba, samba-server, samba-client, samba-common,
@@ -4564,7 +4564,7 @@
                         Script Verification:
                             To manually verify, Ensure none of the following remote access packages
                         exist in the folder /usr/lib/apk/db/ Packages:
-                            openssh, openssh-server, dropbear,
+                            openssh, openssh-server, openssh-sftp-server, dropbear,
                         tigervnc, tigervnc-server, tigervnc-viewer,
                             xrdp, xorgxrdp, vsftpd, proftpd, webmin, cockpit, cockpit-ws,
                         cockpit-bridge, nfs-utils, samba, samba-server, samba-client, samba-common,
@@ -4598,7 +4598,7 @@
                         Script Verification:
                             To manually verify, Ensure none of the following remote access packages
                         exist in the folder /usr/lib/apk/db/ Packages:
-                            openssh, openssh-server, dropbear,
+                            openssh, openssh-server, openssh-sftp-server, dropbear,
                         tigervnc, tigervnc-server, tigervnc-viewer,
                             xrdp, xorgxrdp, vsftpd, proftpd, webmin, cockpit, cockpit-ws,
                         cockpit-bridge, nfs-utils, samba, samba-server, samba-client, samba-common,
@@ -4629,7 +4629,7 @@
                         Script Verification:
                             To manually verify, Ensure none of the following remote access packages
                         exist in the folder /usr/lib/apk/db/ Packages:
-                            openssh, openssh-server, dropbear,
+                            openssh, openssh-server, openssh-sftp-server, dropbear,
                         tigervnc, tigervnc-server, tigervnc-viewer,
                             xrdp, xorgxrdp, vsftpd, proftpd, webmin, cockpit, cockpit-ws,
                         cockpit-bridge, nfs-utils, samba, samba-server, samba-client, samba-common,
@@ -4658,7 +4658,7 @@
                             Script Verification:
                             To manually verify, Ensure none of the following remote access packages
                         exist in the folder /usr/lib/apk/db/ Packages:
-                            openssh, openssh-server, dropbear,
+                            openssh, openssh-server, openssh-sftp-server, dropbear,
                         tigervnc, tigervnc-server, tigervnc-viewer,
                             xrdp, xorgxrdp, vsftpd, proftpd, webmin, cockpit, cockpit-ws,
                         cockpit-bridge, nfs-utils, samba, samba-server, samba-client, samba-common,
@@ -4684,7 +4684,7 @@
                         Script Verification:
                             To manually verify, Ensure none of the following remote access packages
                         exist in the folder /usr/lib/apk/db/ Packages:
-                            openssh, openssh-server, dropbear,
+                            openssh, openssh-server, openssh-sftp-server, dropbear,
                         tigervnc, tigervnc-server, tigervnc-viewer,
                             xrdp, xorgxrdp, vsftpd, proftpd, webmin, cockpit, cockpit-ws,
                         cockpit-bridge, nfs-utils, samba, samba-server, samba-client, samba-common,
@@ -4713,7 +4713,7 @@
                             Script Verification:
                             To manually verify, Ensure none of the following remote access packages
                         exist in the folder /usr/lib/apk/db/ Packages:
-                            openssh, openssh-server, dropbear,
+                            openssh, openssh-server, openssh-sftp-server, dropbear,
                         tigervnc, tigervnc-server, tigervnc-viewer,
                             xrdp, xorgxrdp, vsftpd, proftpd, webmin, cockpit, cockpit-ws,
                         cockpit-bridge, nfs-utils, samba, samba-server, samba-client, samba-common,
@@ -4750,7 +4750,7 @@
                             Script Verification:
                             To manually verify, Ensure none of the following remote access packages
                         exist in the folder /usr/lib/apk/db/ Packages:
-                            openssh, openssh-server, dropbear,
+                            openssh, openssh-server, openssh-sftp-server, dropbear,
                         tigervnc, tigervnc-server, tigervnc-viewer,
                             xrdp, xorgxrdp, vsftpd, proftpd, webmin, cockpit, cockpit-ws,
                         cockpit-bridge, nfs-utils, samba, samba-server, samba-client, samba-common,
@@ -4777,7 +4777,7 @@
                         Script Verification:
                             To manually verify, Ensure none of the following remote access packages
                         exist in the folder /usr/lib/apk/db/ Packages:
-                            openssh, openssh-server, dropbear,
+                            openssh, openssh-server, openssh-sftp-server, dropbear,
                         tigervnc, tigervnc-server, tigervnc-viewer,
                             xrdp, xorgxrdp, vsftpd, proftpd, webmin, cockpit, cockpit-ws,
                         cockpit-bridge, nfs-utils, samba, samba-server, samba-client, samba-common,
@@ -4800,7 +4800,7 @@
                             Script Verification:
                             To manually verify, Ensure none of the following remote access packages
                         exist in the folder /usr/lib/apk/db/ Packages:
-                            openssh, openssh-server, dropbear,
+                            openssh, openssh-server, openssh-sftp-server, dropbear,
                         tigervnc, tigervnc-server, tigervnc-viewer,
                             xrdp, xorgxrdp, vsftpd, proftpd, webmin, cockpit, cockpit-ws,
                         cockpit-bridge, nfs-utils, samba, samba-server, samba-client, samba-common,
@@ -4827,7 +4827,7 @@
                             Script Verification:
                             To manually verify, Ensure none of the following remote access packages
                         exist in the folder /usr/lib/apk/db/ Packages:
-                            openssh, openssh-server, dropbear,
+                            openssh, openssh-server, openssh-sftp-server, dropbear,
                         tigervnc, tigervnc-server, tigervnc-viewer,
                             xrdp, xorgxrdp, vsftpd, proftpd, webmin, cockpit, cockpit-ws,
                         cockpit-bridge, nfs-utils, samba, samba-server, samba-client, samba-common,
@@ -4854,7 +4854,7 @@
                             Script Verification:
                             To manually verify, Ensure none of the following remote access packages
                         exist in the folder /usr/lib/apk/db/ Packages:
-                            openssh, openssh-server, dropbear,
+                            openssh, openssh-server, openssh-sftp-server, dropbear,
                         tigervnc, tigervnc-server, tigervnc-viewer,
                             xrdp, xorgxrdp, vsftpd, proftpd, webmin, cockpit, cockpit-ws,
                         cockpit-bridge, nfs-utils, samba, samba-server, samba-client, samba-common,
@@ -4882,7 +4882,7 @@
                             Script Verification:
                             To manually verify, Ensure none of the following remote access packages
                         exist in the folder /usr/lib/apk/db/ Packages:
-                            openssh, openssh-server, dropbear,
+                            openssh, openssh-server, openssh-sftp-server, dropbear,
                         tigervnc, tigervnc-server, tigervnc-viewer,
                             xrdp, xorgxrdp, vsftpd, proftpd, webmin, cockpit, cockpit-ws,
                         cockpit-bridge, nfs-utils, samba, samba-server, samba-client, samba-common,
@@ -4904,7 +4904,7 @@
                             Script Verification:
                             To manually verify, Ensure none of the following remote access packages
                         exist in the folder /usr/lib/apk/db/ Packages:
-                            openssh, openssh-server, dropbear,
+                            openssh, openssh-server, openssh-sftp-server, dropbear,
                         tigervnc, tigervnc-server, tigervnc-viewer,
                             xrdp, xorgxrdp, vsftpd, proftpd, webmin, cockpit, cockpit-ws,
                         cockpit-bridge, nfs-utils, samba, samba-server, samba-client, samba-common,
@@ -4953,7 +4953,7 @@
                             Script Verification:
                             To manually verify, Ensure none of the following remote access packages
                         exist in the folder /usr/lib/apk/db/ Packages:
-                            openssh, openssh-server, dropbear,
+                            openssh, openssh-server, openssh-sftp-server, dropbear,
                         tigervnc, tigervnc-server, tigervnc-viewer,
                             xrdp, xorgxrdp, vsftpd, proftpd, webmin, cockpit, cockpit-ws,
                         cockpit-bridge, nfs-utils, samba, samba-server, samba-client, samba-common,
@@ -4984,7 +4984,7 @@
                             Script Verification:
                             To manually verify, Ensure none of the following remote access packages
                         exist in the folder /usr/lib/apk/db/ Packages:
-                            openssh, openssh-server, dropbear,
+                            openssh, openssh-server, openssh-sftp-server, dropbear,
                         tigervnc, tigervnc-server, tigervnc-viewer,
                             xrdp, xorgxrdp, vsftpd, proftpd, webmin, cockpit, cockpit-ws,
                         cockpit-bridge, nfs-utils, samba, samba-server, samba-client, samba-common,
@@ -5011,7 +5011,7 @@
                             Script Verification:
                             To manually verify, Ensure none of the following remote access packages
                         exist in the folder /usr/lib/apk/db/ Packages:
-                            openssh, openssh-server, dropbear,
+                            openssh, openssh-server, openssh-sftp-server, dropbear,
                         tigervnc, tigervnc-server, tigervnc-viewer,
                             xrdp, xorgxrdp, vsftpd, proftpd, webmin, cockpit, cockpit-ws,
                         cockpit-bridge, nfs-utils, samba, samba-server, samba-client, samba-common,
@@ -5041,7 +5041,7 @@
                             Script Verification:
                             To manually verify, Ensure none of the following remote access packages
                         exist in the folder /usr/lib/apk/db/ Packages:
-                            openssh, openssh-server, dropbear,
+                            openssh, openssh-server, openssh-sftp-server, dropbear,
                         tigervnc, tigervnc-server, tigervnc-viewer,
                             xrdp, xorgxrdp, vsftpd, proftpd, webmin, cockpit, cockpit-ws,
                         cockpit-bridge, nfs-utils, samba, samba-server, samba-client, samba-common,
@@ -5090,7 +5090,7 @@
                             Script Verification:
                             To manually verify, Ensure none of the following remote access packages
                         exist in the folder /usr/lib/apk/db/ Packages:
-                            openssh, openssh-server, dropbear,
+                            openssh, openssh-server, openssh-sftp-server, dropbear,
                         tigervnc, tigervnc-server, tigervnc-viewer,
                             xrdp, xorgxrdp, vsftpd, proftpd, webmin, cockpit, cockpit-ws,
                         cockpit-bridge, nfs-utils, samba, samba-server, samba-client, samba-common,
@@ -5111,7 +5111,7 @@
                             Script Verification:
                             To manually verify, Ensure none of the following remote access packages
                         exist in the folder /usr/lib/apk/db/ Packages:
-                            openssh, openssh-server, dropbear,
+                            openssh, openssh-server, openssh-sftp-server, dropbear,
                         tigervnc, tigervnc-server, tigervnc-viewer,
                             xrdp, xorgxrdp, vsftpd, proftpd, webmin, cockpit, cockpit-ws,
                         cockpit-bridge, nfs-utils, samba, samba-server, samba-client, samba-common,
@@ -5135,7 +5135,7 @@
                             Script Verification:
                             To manually verify, Ensure none of the following remote access packages
                         exist in the folder /usr/lib/apk/db/ Packages:
-                            openssh, openssh-server, dropbear,
+                            openssh, openssh-server, openssh-sftp-server, dropbear,
                         tigervnc, tigervnc-server, tigervnc-viewer,
                             xrdp, xorgxrdp, vsftpd, proftpd, webmin, cockpit, cockpit-ws,
                         cockpit-bridge, nfs-utils, samba, samba-server, samba-client, samba-common,
@@ -5164,7 +5164,7 @@
                         Script Verification:
                             To manually verify, Ensure none of the following remote access packages
                         exist in the folder /usr/lib/apk/db/ Packages:
-                            openssh, openssh-server, dropbear,
+                            openssh, openssh-server, openssh-sftp-server, dropbear,
                         tigervnc, tigervnc-server, tigervnc-viewer,
                             xrdp, xorgxrdp, vsftpd, proftpd, webmin, cockpit, cockpit-ws,
                         cockpit-bridge, nfs-utils, samba, samba-server, samba-client, samba-common,
@@ -5202,7 +5202,7 @@
                         Script Verification:
                             To manually verify, Ensure none of the following remote access packages
                         exist in the folder /usr/lib/apk/db/ Packages:
-                            openssh, openssh-server, dropbear,
+                            openssh, openssh-server, openssh-sftp-server, dropbear,
                         tigervnc, tigervnc-server, tigervnc-viewer,
                             xrdp, xorgxrdp, vsftpd, proftpd, webmin, cockpit, cockpit-ws,
                         cockpit-bridge, nfs-utils, samba, samba-server, samba-client, samba-common,
@@ -5231,7 +5231,7 @@
                             Script Verification:
                             To manually verify, Ensure none of the following remote access packages
                         exist in the folder /usr/lib/apk/db/ Packages:
-                            openssh, openssh-server, dropbear,
+                            openssh, openssh-server, openssh-sftp-server, dropbear,
                         tigervnc, tigervnc-server, tigervnc-viewer,
                             xrdp, xorgxrdp, vsftpd, proftpd, webmin, cockpit, cockpit-ws,
                         cockpit-bridge, nfs-utils, samba, samba-server, samba-client, samba-common,
@@ -5261,7 +5261,7 @@
                         Script Verification:
                             To manually verify, Ensure none of the following remote access packages
                         exist in the folder /usr/lib/apk/db/ Packages:
-                            openssh, openssh-server, dropbear,
+                            openssh, openssh-server, openssh-sftp-server, dropbear,
                         tigervnc, tigervnc-server, tigervnc-viewer,
                             xrdp, xorgxrdp, vsftpd, proftpd, webmin, cockpit, cockpit-ws,
                         cockpit-bridge, nfs-utils, samba, samba-server, samba-client, samba-common,
@@ -5291,7 +5291,7 @@
                         Script Verification:
                             To manually verify, Ensure none of the following remote access packages
                         exist in the folder /usr/lib/apk/db/ Packages:
-                            openssh, openssh-server, dropbear,
+                            openssh, openssh-server, openssh-sftp-server, dropbear,
                         tigervnc, tigervnc-server, tigervnc-viewer,
                             xrdp, xorgxrdp, vsftpd, proftpd, webmin, cockpit, cockpit-ws,
                         cockpit-bridge, nfs-utils, samba, samba-server, samba-client, samba-common,
@@ -5320,7 +5320,7 @@
                         Script Verification:
                             To manually verify, Ensure none of the following remote access packages
                         exist in the folder /usr/lib/apk/db/ Packages:
-                            openssh, openssh-server, dropbear,
+                            openssh, openssh-server, openssh-sftp-server, dropbear,
                         tigervnc, tigervnc-server, tigervnc-viewer,
                             xrdp, xorgxrdp, vsftpd, proftpd, webmin, cockpit, cockpit-ws,
                         cockpit-bridge, nfs-utils, samba, samba-server, samba-client, samba-common,
@@ -5350,7 +5350,7 @@
                             Script Verification:
                             To manually verify, Ensure none of the following remote access packages
                         exist in the folder /usr/lib/apk/db/ Packages:
-                            openssh, openssh-server, dropbear,
+                            openssh, openssh-server, openssh-sftp-server, dropbear,
                         tigervnc, tigervnc-server, tigervnc-viewer,
                             xrdp, xorgxrdp, vsftpd, proftpd, webmin, cockpit, cockpit-ws,
                         cockpit-bridge, nfs-utils, samba, samba-server, samba-client, samba-common,
@@ -6755,7 +6755,7 @@
         <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:org.RemoteAccessServices:obj:6" version="1">
           <path>/usr/lib/apk/db</path>
           <filename>installed</filename>
-          <pattern operation="pattern match">^P:(openssh|openssh-server|dropbear|tigervnc|tigervnc-server|tigervnc-viewer|xrdp|xorgxrdp|vsftpd|proftpd|webmin|cockpit|cockpit-ws|cockpit-bridge|nfs-utils|samba|samba-server|samba-client|samba-common|rsh|telnet)(-\d[\d.]*(-[a-z][a-z0-9-]*)?)?$</pattern>
+          <pattern operation="pattern match">^P:(openssh|openssh-server|openssh-sftp-server|dropbear|tigervnc|tigervnc-server|tigervnc-viewer|xrdp|xorgxrdp|vsftpd|proftpd|webmin|cockpit|cockpit-ws|cockpit-bridge|nfs-utils|samba|samba-server|samba-client|samba-common|rsh|telnet)(-\d[\d.]*(-[a-z][a-z0-9-]*)?)?$</pattern>
           <instance datatype="int">1</instance>
         </textfilecontent54_object>
       </objects>

--- a/tests/oscap-offline/internal/scan/fixtures_test.go
+++ b/tests/oscap-offline/internal/scan/fixtures_test.go
@@ -289,9 +289,17 @@ func (h harness) scanFixture(t *testing.T, ops []overlay.Op, containerVars []str
 //   - DetectOpenSsl gates its SSH criteria on these: the client checks apply
 //     only when openssh-client is recorded and the server checks only when
 //     openssh-server is recorded.
+// apkOpenSSHSftpServerStanza records openssh-sftp-server, which ships the
+// sftp-server subsystem binary sshd serves and is banned alongside the server.
+// It is listed separately from openssh-server in the pattern, so it needs its
+// own row: the "-sftp-server" spelling is not reached by the openssh-server
+// alternative, which is anchored against a version suffix rather than a word
+// one. This package was added to the ban list without the datastream copy
+// following, so the shipped rule missed it entirely — see the fail row below.
 var (
-	apkOpenSSHClientStanza = []byte("\nP:openssh-client\nV:9.9_p2-r0\nA:x86_64\n")
-	apkOpenSSHServerStanza = []byte("\nP:openssh-server\nV:9.9_p2-r0\nA:x86_64\n")
+	apkOpenSSHClientStanza     = []byte("\nP:openssh-client\nV:9.9_p2-r0\nA:x86_64\n")
+	apkOpenSSHServerStanza     = []byte("\nP:openssh-server\nV:9.9_p2-r0\nA:x86_64\n")
+	apkOpenSSHSftpServerStanza = []byte("\nP:openssh-sftp-server\nV:9.9_p2-r0\nA:x86_64\n")
 )
 
 // apkDropbearStanza is an apk installed-db record whose P: line matches the
@@ -519,6 +527,16 @@ func matrixCases() []matrixCase {
 			// so an `apk add openssh` image fails here too.)
 			name: "remote_access/fail_openssh_server_installed",
 			ops:  []overlay.Op{overlay.AppendFile("usr/lib/apk/db/installed", apkOpenSSHServerStanza)},
+			want: map[string]results.Result{ruleRemoteAccessServices: results.Fail},
+		},
+		{
+			// openssh-sftp-server ships the sftp-server subsystem and is banned in
+			// its own right. It is a distinct alternative in the pattern rather than
+			// a suffix of openssh-server, so nothing else covers it: before this row
+			// the datastream had lost the package while the standalone OVAL kept it,
+			// and no test noticed.
+			name: "remote_access/fail_openssh_sftp_server_installed",
+			ops:  []overlay.Op{overlay.AppendFile("usr/lib/apk/db/installed", apkOpenSSHSftpServerStanza)},
 			want: map[string]results.Result{ruleRemoteAccessServices: results.Fail},
 		},
 		{


### PR DESCRIPTION
## Summary

`openssh-sftp-server` is in the remote-access ban list in two of the three
places this content lives, but **not** in the combined datastream — the copy
`oscap-docker` and the `openscap` image actually evaluate. So the shipped
`RemoteAccessServices` rule has not been flagging the package at all, through
v3.2.16, while the standalone OVAL check says it should.

## How it happened

Entirely within #132's own history:

| Commit | Date | PR | `ds.xml` | `RemoteAccessServicesTest.xml` | `XccdfOvalChecks.xml` |
|---|---|---|---|---|---|
| `5912aa2` | 2024-07-09 | #1 | +48 | +1 | +47 |
| `6366daa` | 2026-07-23 | #132 | −47 | −1 | −47 |
| `ca67831` | 2026-08-13 | #132 | **0** | +1 | +47 |

#1 introduced the package consistently. #132's `6366daa` removed it
consistently — that part was clean. Three weeks later `ca67831` ("add
openssh-sftp-server as well") re-added it to two copies and left the datastream
at zero.

Nothing else covered the gap: `openssh-sftp-server` is a distinct alternative in
the pattern rather than a suffix of `openssh-server`, whose alternative is
anchored against a *version* suffix and so never reaches the `-sftp-server`
spelling.

## Change

Bring the datastream into line — the OVAL pattern, plus the 46 rule
descriptions that enumerate the same package list. The pattern is now
byte-identical to the standalone file's, and a semantic diff of the two
`RemoteAccessServices` definitions reports zero remaining differences.

Add `remote_access/fail_openssh_sftp_server_installed` to the offline matrix so
the gap cannot reopen silently. It earns its place: run against the pattern as
it stood on `main`, the row fails with the rule returning `pass` where `fail` is
expected.

## Root cause is systemic, and not fixed here

This content lives in **three** hand-synced copies —
`OvalDefinitions/*.xml`, `OvalChecks/XccdfOvalChecks.xml`, and the embedded
datastream — with no generation step and nothing comparing them. Each copy is
validated against its schema in isolation, which is exactly why a change to two
of three passed CI.

A mirror-consistency check would have caught this and is worth adding
separately. Note that five of the seven standalone files still differ
cosmetically from their embedded counterparts (`<reference source="Custom">` vs
`"CIS"`), so which spelling is canonical needs deciding before such a check can
go green.

## Verification

- `xmllint --noout`: well-formed.
- `oscap ds sds-validate`: rc=0.
- `oscap xccdf validate`: 235 errors, identical to `main` — no new ones.
- Full offline matrix green: 47 subtests, 0 failures, one new row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)