### PR TITLE
Add the standalone CertificateAuditTest.xml, derived from the datastream

### DIFF
--- a/gpos/xml/scap/ssg/content/ssg-chainguard-xccdf/OvalDefinitions/CertificateAuditTest.xml
+++ b/gpos/xml/scap/ssg/content/ssg-chainguard-xccdf/OvalDefinitions/CertificateAuditTest.xml
@@ -1,0 +1,175 @@
+<?xml version="1.0"?>
+<oval_definitions xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ind="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" xmlns:unix="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix" xsi:schemaLocation="http://oval.mitre.org/XMLSchema/oval-definitions-5 http://oval.mitre.org/language/download/schema/version5.10.1/ovaldefinition/complete/oval-definitions-schema.xsd">
+  <generator>
+    <oval:product_name>Custom</oval:product_name>
+    <oval:product_version>1.0</oval:product_version>
+    <oval:schema_version>5.11.1</oval:schema_version>
+    <oval:timestamp>2025-05-27T12:00:00</oval:timestamp>
+  </generator>
+  <definitions>
+    <definition id="oval:org.CABundleHash:def:1" version="1" class="compliance">
+      <metadata>
+        <title>Validate SHA-256 hash of CA bundle</title>
+        <description>Passes only if the CA bundle exists, its SHA-256 matches the digest recorded in the ca-certificates package stamp file /etc/ssl/certs/.ca-certificates.crt.sha256, and the SSL_CERT_FILE environment variable configured on the image or container is set to /etc/ssl/certs/ca-certificates.crt. Images that carry a second copy of the bundle at /kaniko/ssl/certs/ca-certificates.crt may point SSL_CERT_FILE there instead; that copy is then held to the digest in its own stamp file /kaniko/ssl/certs/.ca-certificates.crt.sha256 where the image ships one, and otherwise to the digest in the system stamp file. A stamp file beside the copy takes precedence, so it cannot be sidestepped by the system one, and an unverified or divergent copy cannot satisfy the rule. Java images additionally ship a JKS/PKCS12 truststore at /etc/ssl/certs/java/cacerts; when that file is present it must likewise match the digest in /etc/ssl/certs/java/.cacerts.sha256. Images without Java carry no truststore and are unaffected.</description>
+        <affected family="unix">
+          <platform>Chainguard</platform>
+        </affected>
+      </metadata>
+      <criteria operator="AND">
+        <criterion test_ref="oval:org.CABundleHash:tst:1" comment="Ensure CA bundle file exists"/>
+        <criterion test_ref="oval:org.CABundleHash:tst:4" comment="Ensure CA bundle checksum stamp file exists and is well formed"/>
+        <criterion test_ref="oval:org.CABundleHash:tst:2" comment="Ensure CA bundle hash matches the checksum stamp file"/>
+        <criteria operator="OR" comment="SSL_CERT_FILE names a copy of the CA bundle verified against a checksum stamp file">
+          <criterion test_ref="oval:org.CABundleHash:tst:3" comment="Ensure SSL_CERT_FILE is set to the system CA bundle path"/>
+          <criteria operator="AND" comment="Images carrying the bundle under /kaniko may point SSL_CERT_FILE at that copy">
+            <criterion test_ref="oval:org.CABundleHash:tst:8" comment="Ensure the /kaniko CA bundle copy exists"/>
+            <criteria operator="OR" comment="The /kaniko copy matches its own checksum stamp file where one is shipped beside it, otherwise the system one">
+              <criteria operator="AND" comment="Stamp file shipped beside the /kaniko copy takes precedence">
+                <criterion test_ref="oval:org.CABundleHash:tst:11" comment="Ensure the /kaniko checksum stamp file exists and is well formed"/>
+                <criterion test_ref="oval:org.CABundleHash:tst:12" comment="Ensure the /kaniko CA bundle copy matches the /kaniko checksum stamp file"/>
+              </criteria>
+              <criteria operator="AND" comment="No stamp file beside the /kaniko copy, so fall back to the system one">
+                <criterion test_ref="oval:org.CABundleHash:tst:13" comment="No checksum stamp file beside the /kaniko CA bundle copy"/>
+                <criterion test_ref="oval:org.CABundleHash:tst:9" comment="Ensure the /kaniko CA bundle copy matches the system checksum stamp file"/>
+              </criteria>
+            </criteria>
+            <criterion test_ref="oval:org.CABundleHash:tst:10" comment="Ensure SSL_CERT_FILE is set to the /kaniko CA bundle path"/>
+          </criteria>
+        </criteria>
+        <criteria operator="OR" comment="Java truststore, where one is present, matches its checksum stamp file">
+          <criterion test_ref="oval:org.CABundleHash:tst:5" comment="No Java truststore present (non-Java image)"/>
+          <criteria operator="AND">
+            <criterion test_ref="oval:org.CABundleHash:tst:6" comment="Ensure Java truststore checksum stamp file exists and is well formed"/>
+            <criterion test_ref="oval:org.CABundleHash:tst:7" comment="Ensure Java truststore hash matches the checksum stamp file"/>
+          </criteria>
+        </criteria>
+      </criteria>
+    </definition>
+  </definitions>
+  <tests>
+    <unix:file_test id="oval:org.CABundleHash:tst:1" version="1" check="all" check_existence="only_one_exists" comment="Ensure CA bundle file exists">
+      <unix:object object_ref="oval:org.CABundleHash:obj:1"/>
+    </unix:file_test>
+    <ind:filehash58_test id="oval:org.CABundleHash:tst:2" version="1" check="all" check_existence="only_one_exists" comment="Check that CA bundle file matches the SHA-256 recorded in its checksum stamp file">
+      <ind:object object_ref="oval:org.CABundleHash:obj:2"/>
+      <ind:state state_ref="oval:org.CABundleHash:ste:1"/>
+    </ind:filehash58_test>
+    <ind:textfilecontent54_test id="oval:org.CABundleHash:tst:4" version="1" check="all" check_existence="only_one_exists" comment="Checksum stamp file exists and contains a single SHA-256 digest for ca-certificates.crt">
+      <ind:object object_ref="oval:org.CABundleHash:obj:4"/>
+    </ind:textfilecontent54_test>
+    <ind:environmentvariable58_test id="oval:org.CABundleHash:tst:3" version="1" check="all" check_existence="all_exist" comment="SSL_CERT_FILE equals /etc/ssl/certs/ca-certificates.crt">
+      <ind:object object_ref="oval:org.CABundleHash:obj:3"/>
+      <ind:state state_ref="oval:org.CABundleHash:ste:2"/>
+    </ind:environmentvariable58_test>
+    <unix:file_test id="oval:org.CABundleHash:tst:5" version="1" check="all" check_existence="none_exist" comment="No Java truststore at /etc/ssl/certs/java/cacerts">
+      <unix:object object_ref="oval:org.CABundleHash:obj:5"/>
+    </unix:file_test>
+    <ind:textfilecontent54_test id="oval:org.CABundleHash:tst:6" version="1" check="all" check_existence="only_one_exists" comment="Java truststore stamp file exists and contains a single SHA-256 digest for cacerts">
+      <ind:object object_ref="oval:org.CABundleHash:obj:6"/>
+    </ind:textfilecontent54_test>
+    <ind:filehash58_test id="oval:org.CABundleHash:tst:7" version="1" check="all" check_existence="only_one_exists" comment="Check that the Java truststore matches the SHA-256 recorded in its checksum stamp file">
+      <ind:object object_ref="oval:org.CABundleHash:obj:7"/>
+      <ind:state state_ref="oval:org.CABundleHash:ste:3"/>
+    </ind:filehash58_test>
+    <unix:file_test id="oval:org.CABundleHash:tst:8" version="1" check="all" check_existence="only_one_exists" comment="Ensure the /kaniko CA bundle copy exists">
+      <unix:object object_ref="oval:org.CABundleHash:obj:8"/>
+    </unix:file_test>
+    <ind:filehash58_test id="oval:org.CABundleHash:tst:9" version="1" check="all" check_existence="only_one_exists" comment="Check that the /kaniko CA bundle copy matches the SHA-256 recorded in the system ca-certificates checksum stamp file">
+      <ind:object object_ref="oval:org.CABundleHash:obj:9"/>
+      <ind:state state_ref="oval:org.CABundleHash:ste:1"/>
+    </ind:filehash58_test>
+    <ind:environmentvariable58_test id="oval:org.CABundleHash:tst:10" version="1" check="all" check_existence="all_exist" comment="SSL_CERT_FILE equals /kaniko/ssl/certs/ca-certificates.crt">
+      <ind:object object_ref="oval:org.CABundleHash:obj:3"/>
+      <ind:state state_ref="oval:org.CABundleHash:ste:4"/>
+    </ind:environmentvariable58_test>
+    <ind:textfilecontent54_test id="oval:org.CABundleHash:tst:11" version="1" check="all" check_existence="only_one_exists" comment="Checksum stamp file beside the /kaniko copy exists and contains a single SHA-256 digest for ca-certificates.crt">
+      <ind:object object_ref="oval:org.CABundleHash:obj:10"/>
+    </ind:textfilecontent54_test>
+    <ind:filehash58_test id="oval:org.CABundleHash:tst:12" version="1" check="all" check_existence="only_one_exists" comment="Check that the /kaniko CA bundle copy matches the SHA-256 recorded in the stamp file beside it">
+      <ind:object object_ref="oval:org.CABundleHash:obj:9"/>
+      <ind:state state_ref="oval:org.CABundleHash:ste:5"/>
+    </ind:filehash58_test>
+    <unix:file_test id="oval:org.CABundleHash:tst:13" version="1" check="all" check_existence="none_exist" comment="No checksum stamp file at /kaniko/ssl/certs/.ca-certificates.crt.sha256">
+      <unix:object object_ref="oval:org.CABundleHash:obj:11"/>
+    </unix:file_test>
+  </tests>
+  <objects>
+    <unix:file_object id="oval:org.CABundleHash:obj:1" version="1">
+      <unix:filepath>/etc/ssl/certs/ca-certificates.crt</unix:filepath>
+    </unix:file_object>
+    <ind:filehash58_object id="oval:org.CABundleHash:obj:2" version="1">
+      <ind:filepath>/etc/ssl/certs/ca-certificates.crt</ind:filepath>
+      <ind:hash_type>SHA-256</ind:hash_type>
+    </ind:filehash58_object>
+    <ind:environmentvariable58_object id="oval:org.CABundleHash:obj:3" version="1">
+      <ind:pid xsi:nil="true" datatype="int"/>
+      <ind:name>SSL_CERT_FILE</ind:name>
+    </ind:environmentvariable58_object>
+    <ind:textfilecontent54_object id="oval:org.CABundleHash:obj:4" version="1" comment="SHA-256 digest recorded by the ca-certificates package alongside the bundle">
+      <ind:path>/etc/ssl/certs</ind:path>
+      <ind:filename>.ca-certificates.crt.sha256</ind:filename>
+      <ind:pattern operation="pattern match">^([0-9a-fA-F]{64})[ \t]+\*?ca-certificates\.crt$</ind:pattern>
+      <ind:instance datatype="int">1</ind:instance>
+    </ind:textfilecontent54_object>
+    <unix:file_object id="oval:org.CABundleHash:obj:5" version="1" comment="Java truststore, present only in Java-based images">
+      <unix:filepath>/etc/ssl/certs/java/cacerts</unix:filepath>
+    </unix:file_object>
+    <ind:textfilecontent54_object id="oval:org.CABundleHash:obj:6" version="1" comment="SHA-256 digest recorded alongside the Java truststore">
+      <ind:path>/etc/ssl/certs/java</ind:path>
+      <ind:filename>.cacerts.sha256</ind:filename>
+      <ind:pattern operation="pattern match">^([0-9a-fA-F]{64})[ \t]+\*?cacerts$</ind:pattern>
+      <ind:instance datatype="int">1</ind:instance>
+    </ind:textfilecontent54_object>
+    <ind:filehash58_object id="oval:org.CABundleHash:obj:7" version="1">
+      <ind:filepath>/etc/ssl/certs/java/cacerts</ind:filepath>
+      <ind:hash_type>SHA-256</ind:hash_type>
+    </ind:filehash58_object>
+    <unix:file_object id="oval:org.CABundleHash:obj:8" version="1" comment="CA bundle copy, present only in images that carry one under /kaniko">
+      <unix:filepath>/kaniko/ssl/certs/ca-certificates.crt</unix:filepath>
+    </unix:file_object>
+    <ind:filehash58_object id="oval:org.CABundleHash:obj:9" version="1">
+      <ind:filepath>/kaniko/ssl/certs/ca-certificates.crt</ind:filepath>
+      <ind:hash_type>SHA-256</ind:hash_type>
+    </ind:filehash58_object>
+    <ind:textfilecontent54_object id="oval:org.CABundleHash:obj:10" version="1" comment="SHA-256 digest recorded beside the /kaniko CA bundle copy, where the image ships one">
+      <ind:path>/kaniko/ssl/certs</ind:path>
+      <ind:filename>.ca-certificates.crt.sha256</ind:filename>
+      <ind:pattern operation="pattern match">^([0-9a-fA-F]{64})[ \t]+\*?ca-certificates\.crt$</ind:pattern>
+      <ind:instance datatype="int">1</ind:instance>
+    </ind:textfilecontent54_object>
+    <unix:file_object id="oval:org.CABundleHash:obj:11" version="1" comment="Stamp file beside the /kaniko copy, as a file so its absence is distinguishable from it being unparseable">
+      <unix:filepath>/kaniko/ssl/certs/.ca-certificates.crt.sha256</unix:filepath>
+    </unix:file_object>
+  </objects>
+  <states>
+    <ind:filehash58_state id="oval:org.CABundleHash:ste:1" version="1">
+      <ind:hash_type>SHA-256</ind:hash_type>
+      <ind:hash datatype="string" operation="case insensitive equals" var_ref="oval:org.CABundleHash:var:1" var_check="all"/>
+    </ind:filehash58_state>
+    <ind:environmentvariable58_state id="oval:org.CABundleHash:ste:2" version="1">
+      <ind:value datatype="string" operation="equals">/etc/ssl/certs/ca-certificates.crt</ind:value>
+    </ind:environmentvariable58_state>
+    <ind:filehash58_state id="oval:org.CABundleHash:ste:3" version="1">
+      <ind:hash_type>SHA-256</ind:hash_type>
+      <ind:hash datatype="string" operation="case insensitive equals" var_ref="oval:org.CABundleHash:var:2" var_check="all"/>
+    </ind:filehash58_state>
+    <ind:environmentvariable58_state id="oval:org.CABundleHash:ste:4" version="1">
+      <ind:value datatype="string" operation="equals">/kaniko/ssl/certs/ca-certificates.crt</ind:value>
+    </ind:environmentvariable58_state>
+    <ind:filehash58_state id="oval:org.CABundleHash:ste:5" version="1">
+      <ind:hash_type>SHA-256</ind:hash_type>
+      <ind:hash datatype="string" operation="case insensitive equals" var_ref="oval:org.CABundleHash:var:3" var_check="all"/>
+    </ind:filehash58_state>
+  </states>
+  <variables>
+    <local_variable id="oval:org.CABundleHash:var:1" version="1" datatype="string" comment="Expected CA bundle SHA-256, read from /etc/ssl/certs/.ca-certificates.crt.sha256">
+      <object_component object_ref="oval:org.CABundleHash:obj:4" item_field="subexpression"/>
+    </local_variable>
+    <local_variable id="oval:org.CABundleHash:var:2" version="1" datatype="string" comment="Expected Java truststore SHA-256, read from /etc/ssl/certs/java/.cacerts.sha256">
+      <object_component object_ref="oval:org.CABundleHash:obj:6" item_field="subexpression"/>
+    </local_variable>
+    <local_variable id="oval:org.CABundleHash:var:3" version="1" datatype="string" comment="Expected /kaniko CA bundle SHA-256, read from /kaniko/ssl/certs/.ca-certificates.crt.sha256 where the image ships one">
+      <object_component object_ref="oval:org.CABundleHash:obj:10" item_field="subexpression"/>
+    </local_variable>
+  </variables>
+</oval_definitions>


### PR DESCRIPTION
## Why

`CertificateAudit` was the only OVAL component the datastream *references* that
had no standalone file. The datastream names `CertificateAuditTest.xml` in both
its component catalog and the rule's `check-content-ref` — a file that did not
exist in the repo. Two consequences:

- it was the one check that could not be evaluated on its own with
  `oscap oval eval`; and
- regeneration had no input for it. `chainguard-dev/oscap-playground` assembles
  the datastream by reading each standalone file and embedding it verbatim, and
  its `component_id_mapping` expects `'CertificateAuditTest.xml': 'certaudit'`
  by that exact name.

## Derived, not copied

The generator's own copy of this file is stale to the point of being harmful:
**2 tests** against the current **13**, a hardcoded `<hash>` literal predating
even the old pinned value, and no sidecar variable, no `/kaniko` criteria and no
Java truststore. Copying it would have reverted the rule to roughly its 2025
shape.

Instead the `<oval_definitions>` element is lifted out of the `certaudit`
extended-component verbatim and dedented, so the standalone file and the
embedded copy are identical **by construction** rather than by transcription.
That matters because nothing but the mirror check in #163 keeps the two in step.

## Verification

| Check | Result |
|---|---|
| `xmllint --noout` | well-formed |
| `oscap oval validate` | rc=0 |
| `oscap oval eval` | runs the definition standalone — the capability that was missing |
| `make validate_checks` | now validates **8** files, exit 0 |
| #163's comparator | `checked 8` (was 7), **0 errors**, no new warnings |

Against #163's comparator, `CertificateAudit` also drops out of the "present
only in the datastream" list, leaving only `oval:org.stub:def:1` — which has no
standalone file either and is not addressed here.

No datastream change: this adds the missing source file to match what the
datastream already declares.

## Relationship to #163

Independent — this is based on `main`, and I verified it against #163's
comparator by extracting the script from that branch rather than by stacking.
Either merge order works: if #163 lands first, CI here exercises the new pair
automatically; if this lands first, #163's `checked` count goes from 7 to 8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)