### PR TITLE
Gate gofmt and go vet on the Go test tooling

### DIFF
--- a/.github/workflows/offline-tests.yaml
+++ b/.github/workflows/offline-tests.yaml
@@ -74,6 +74,12 @@ jobs:
       # endpoints. Compares each standalone OVAL check against its copy in the
       # datastream, which no schema validation covers because each copy is only
       # ever checked against the schema in isolation.
+      # Formatting and full vet. `go test` runs only a subset of vet and no
+      # formatting check at all, so without this an unformatted file reaches
+      # main unnoticed — which is how one did.
+      - name: Lint Go tooling
+        run: make lint-go
+
       - name: Check OVAL mirrors against the datastream
         run: make validate_mirrors
 

--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,27 @@ test-offline-clean:
 
 .PHONY: test-offline test-offline-clean
 
+# Formatting and static analysis for the Go test tooling. Neither was gated
+# anywhere until now: CI ran `go test` only, so an unformatted file reached main
+# unnoticed.
+#
+# gofmt -l is checked by its output rather than its exit status on purpose — it
+# exits 0 whether or not it lists anything, so `gofmt -l . && ...` silently
+# succeeds on unformatted input. `go test` runs only a subset of vet, so vet is
+# run in full here to cover the rest.
+lint-go:
+	@cd tests/oscap-offline && \
+	  unformatted=$$(gofmt -l .); \
+	  if [ -n "$$unformatted" ]; then \
+	    echo "::error::gofmt: these files are not formatted; run 'gofmt -w' on them:"; \
+	    echo "$$unformatted" | sed 's/^/  /'; \
+	    exit 1; \
+	  fi; \
+	  echo "gofmt: clean"; \
+	  go vet ./... && echo "go vet: clean"
+
+.PHONY: lint-go
+
 # Trust-store sidecar guard. CertificateAudit pins no digest; it reads each
 # expected value from a sidecar file the image build writes beside the trust
 # store. This target checks that premise against a real image: the sidecars

--- a/README.md
+++ b/README.md
@@ -151,6 +151,13 @@ The comparison lives in
 it also runs as part of `make test-offline` and on PRs via the offline
 workflow.
 
+**Go tooling lint** — `make lint-go` checks `gofmt` and runs `go vet`
+in full across `tests/oscap-offline`. Neither was gated before: CI ran
+`go test` only, which applies no formatting check and only a subset of
+vet, so an unformatted file reached `main` unnoticed. Note `gofmt -l`
+exits 0 whether or not it lists anything, so the target inspects its
+output rather than its exit status.
+
 ### Tier 1 (fast) — offline Go harness
 
 `make test-offline` runs the `tests/oscap-offline` Go module. For each


### PR DESCRIPTION
## Why

Neither `gofmt` nor `go vet` was checked anywhere. CI runs `go test` only, which
applies no formatting check and enables just a subset of vet — so an unformatted
file reached `main` unnoticed (the stanza comment added in #162, fixed in passing
in #163). A gate that would have caught it costs one step.

There is no `.pre-commit-config.yaml` in the repo and no golangci config either,
so this is CI-only. Pre-commit could be added on top later; CI is the
authoritative gate and doesn't depend on per-clone setup.

## Change

`make lint-go` checks `gofmt` and runs `go vet` in full across
`tests/oscap-offline`, and the offline workflow runs it. Documented in the
README's testing section alongside the other gates.

## One detail worth keeping

`gofmt -l` is checked by its **output**, not its exit status:

```make
unformatted=$$(gofmt -l .); \
if [ -n "$$unformatted" ]; then ... exit 1; fi
```

`gofmt -l` exits 0 whether or not it lists anything, so the natural
`gofmt -l . && ...` succeeds on unformatted input. That is precisely the trap
that made the original violation invisible — and it also cost me a wrong
conclusion while diagnosing it, before I re-checked. Hence the comment in the
recipe.

## Verification

Exercised against both failure modes with deliberately broken files, then
removed:

| Probe | Result |
|---|---|
| unformatted file | fails, naming the file |
| formatted file with a vet problem (`Printf` verb mismatch) | fails, naming the diagnostic |
| clean tree (`main` as it stands) | passes — `gofmt: clean`, `go vet: clean` |

`actionlint` issue count unchanged from `main`; `zizmor` no findings.

## Noted separately, not changed here

`make validate_mirrors` and `make test-offline` both run `go test` without `-v`,
so their CI logs show `ok` but not what was covered — #164's run, for instance,
passes the mirror test without the log showing that it compared 8 files. Adding
`-v` (or an explicit count assertion) would make that signal auditable. Happy to
do it, but it is a different concern from linting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)