### PR TITLE
Run the Go test suites verbosely so CI shows what executed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ validate: validate_checks validate_xml
 #
 # Runs as part of `make test-offline` too, since that runs the whole module.
 validate_mirrors:
-	cd tests/oscap-offline && go test -count=1 ./internal/mirrors/
+	cd tests/oscap-offline && go test -v -count=1 ./internal/mirrors/
 
 .PHONY: validate validate_xml validate_checks validate_mirrors
 
@@ -42,12 +42,17 @@ test-e2e-%:
 
 .PHONY: test-e2e
 
+# Run verbosely so the CI log names every test and subtest that executed. A
+# bare `go test` prints only `ok <package>`, which cannot distinguish a suite
+# that ran from one that silently covered less than expected — a newly added
+# table row or fixture that never runs looks identical to one that passes.
+#
 # Fast offline scan tier. Runs the tests/oscap-offline Go harness, which
 # scans an extracted rootfs with oscap pointed at it via OSCAP_PROBE_ROOT
 # (no privileged oscap-docker, no docker socket mount). Drives a per-OVAL-
 # definition pass+fail matrix and asserts the XCCDF rule verdicts.
 test-offline:
-	cd tests/oscap-offline && go test -race -count=1 ./...
+	cd tests/oscap-offline && go test -v -race -count=1 ./...
 
 # Clear the Go test cache so the next `test-offline` re-runs every scan from
 # scratch. The harness caches base tar(s) under a per-run temp dir (t.TempDir),


### PR DESCRIPTION
## Why

A bare `go test` prints only `ok <package>`. That cannot distinguish a suite
that ran from one that silently covered less than expected — a newly added
table row or fixture that never runs looks exactly like one that passes.

Not hypothetical here: the offline matrix pairs fixtures with **package-level**
blobs, which Go does not report as unused, so a row dropped in a refactor leaves
a compiling, green, quieter suite. Nothing in the log would say so.

The immediate prompt was #164. It passes the mirror check in CI, but the log
showed only `ok` — so the thing that PR is *about*, the compared-file count
going from 7 to 8, could not be confirmed from the run at all.

## Change

`-v` on `test-offline` and `validate_mirrors`. One-line each, plus a comment
explaining why.

## What the logs now show

```
    --- PASS: TestOfflineFixtureMatrix/certificate_audit/fail_java_missing_stamp
    ... 47 matrix rows, each named
    mirrors_test.go:390: compared 7 standalone OVAL file(s) against the datastream
    mirrors_test.go:393: present only in the datastream, so not evaluable with
        `oscap oval eval` and with no input for regeneration: oval:org.stub:def:1
```

The matrix row count and the mirror check's file count are both now readable
from a CI run, so a drop in either is visible rather than inferred.

## Verification

`make validate_mirrors` and `make test-offline` both pass: 169 named subtests,
47 matrix rows, 0 failures. The full offline log grows to 846 lines, which seems
a fair trade for being able to tell a green run from a quiet one.

## Note

Touches the `Makefile`, as does #166. The edits are in different regions
(`lint-go` versus these two recipes) so they should merge cleanly in either
order, but worth knowing if both are in flight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)