### PR TITLE
Make the datastream's OVAL reference sources say Custom, and gate it

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,11 +140,13 @@ this check green is also what makes the next regeneration safe — if the
 datastream already matches what the in-repo sources would produce,
 rebuilding it cannot silently revert anything.
 
-Differences that would change a scan verdict fail; purely descriptive
-ones (titles, descriptions, `<reference source>`) are logged instead,
-since the two copies currently disagree on some of those without
-affecting any result — failing on them would mean disabling the check
-rather than fixing content.
+Any difference fails, reported as either functional (criteria, tests,
+objects, states, variables — these change a scan verdict) or descriptive
+(titles, descriptions, `<reference source>` — these do not). Descriptive
+differences were logged rather than failed while five embedded blocks
+still carried a `<reference source>` of `CIS` against the standalone
+files' `Custom`; that content was corrected and the gate closed behind
+it.
 
 The comparison lives in
 `tests/oscap-offline/internal/mirrors` alongside its own unit tests, so

--- a/gpos/xml/scap/ssg/content/ssg-chainguard-gpos-ds.xml
+++ b/gpos/xml/scap/ssg/content/ssg-chainguard-gpos-ds.xml
@@ -6312,7 +6312,7 @@
           <metadata>
             <title>Check for OpenSSL FIPS Packages</title>
             <description>Ensure that the necessary OpenSSL FIPS packages and configuration files are present, and that the OPENSSL_CONF environment variable is either unset or set to /etc/ssl/openssl.cnf. Additionally verify that the OpenSSH client and server FIPS policy drop-ins (/etc/ssh/ssh_config.d/10-ssh-fips.conf and /etc/ssh/sshd_config.d/10-sshd-fips.conf) are present and pin the FIPS-approved ciphers, key-exchange, MAC, and signature algorithms. The main /etc/ssh/ssh_config and /etc/ssh/sshd_config must in turn Include their respective *_config.d/*.conf drop-in directories so the policy is applied. The client checks apply only when openssh-client is installed and the server checks only when openssh-server is installed.</description>
-            <reference source="CIS"/>
+            <reference source="Custom"/>
             <affected family="unix">
               <platform>Chainguard</platform>
             </affected>
@@ -6587,7 +6587,7 @@
           <metadata>
             <title>Check Library Permissions</title>
             <description>Ensure all libraries in /usr/lib have root:root permissions.</description>
-            <reference source="CIS"/>
+            <reference source="Custom"/>
             <affected family="unix">
               <platform>Chainguard</platform>
             </affected>
@@ -6652,7 +6652,7 @@
           <metadata>
             <title>Check for Login-Capable Users in /etc/shadow</title>
             <description>Ensure every entry in /etc/shadow is locked (password field starts with '!' or '*'), i.e. there are no login-capable user accounts. Locked service accounts, such as those apko creates for image run-as users, cannot log in and are permitted.</description>
-            <reference source="CIS"/>
+            <reference source="Custom"/>
             <affected family="unix">
               <platform>Chainguard</platform>
             </affected>
@@ -6774,7 +6774,7 @@
           <metadata>
             <title>No active/unlocked password field in /etc/shadow</title>
             <description>Chainguard container images must not ship interactive shadow password entries; every account must have its shadow field locked (&quot;!&quot; or &quot;*&quot;). This check FAILS if any line in /etc/shadow matches an active/unlocked password field, on the premise that hardened images have no interactive logins.</description>
-            <reference source="CIS"/>
+            <reference source="Custom"/>
             <affected family="unix">
               <platform>Chainguard</platform>
             </affected>
@@ -6812,7 +6812,7 @@
           <metadata>
             <title>Check Var/Log Permissions</title>
             <description>Ensure /var/log has root:root permissions.</description>
-            <reference source="CIS"/>
+            <reference source="Custom"/>
             <affected family="unix">
               <platform>Chainguard</platform>
             </affected>

--- a/tests/oscap-offline/internal/mirrors/doc.go
+++ b/tests/oscap-offline/internal/mirrors/doc.go
@@ -29,13 +29,14 @@
 // variable — is an error: the two copies would evaluate the same image
 // differently.
 //
-// Metadata (title, description, reference, affected) is a warning. The copies
-// disagree today on a <reference source> reading "Custom" in every standalone
-// file and "CIS" in five embedded blocks, which changes no verdict. Since
-// generation copies the standalone file verbatim, the standalone spelling is
-// canonical by construction and those embedded values are simply stale, but
-// correcting them is a content change to the shipped datastream and is not
-// bundled with the comparison itself.
+// Metadata (title, description, reference, affected) is reported separately,
+// because it does not change a verdict — but it is still a failure, since the
+// two copies agree on all of it. They did not always: five embedded blocks
+// carried a <reference source> of "CIS" against the standalone files' "Custom",
+// which is why this started out as a warning. Treating a difference that
+// changes no verdict as fatal while known instances existed would have meant
+// disabling the check rather than fixing content, so the content was corrected
+// first and the gate closed behind it.
 //
 // # Why entities, not a flat node list
 //

--- a/tests/oscap-offline/internal/mirrors/mirrors_test.go
+++ b/tests/oscap-offline/internal/mirrors/mirrors_test.go
@@ -379,8 +379,14 @@ func TestRepositoryMirrorsMatch(t *testing.T) {
 	for _, f := range report.Functional {
 		t.Errorf("functional difference: %s", f)
 	}
+	// Descriptive differences fail too, now that the two copies agree on all of
+	// them. They were logged rather than failed while five embedded blocks still
+	// carried a <reference source> of "CIS" against the standalone files'
+	// "Custom" — a difference that changes no verdict, so failing on it would
+	// have meant disabling this test instead of fixing content. The content is
+	// fixed, so the gate closes behind it.
 	for _, f := range report.Descriptive {
-		t.Logf("descriptive difference (not fatal): %s", f)
+		t.Errorf("descriptive difference: %s", f)
 	}
 
 	// A run that paired nothing would otherwise read as success.


### PR DESCRIPTION
## Problem

Five OVAL definitions embedded in the datastream carried
`<reference source="CIS"/>` while **every** standalone file said `Custom` — and
two embedded blocks said `Custom` too. So the datastream disagreed both with its
sources and with itself.

## `Custom` is the intended value — this is a missed hand-sync, not a judgement call

Commit `3f69d3f` ("All of the formatting", 2025-07-18) deliberately changed
exactly these five references from `CIS` to `Custom` in the standalone files. It
touched the datastream in the same commit — **3402 lines** — and left its
reference sources alone. The standalone value has been `Custom` ever since.

Supporting evidence: the elements carry no `ref_id`, and these are
Chainguard-authored checks for a DISA GPOS SRG profile rather than CIS benchmark
content, so `CIS` asserted a provenance that was not real.

This is the **second confirmed instance** of the same failure class as
`openssh-sftp-server` in #162: a change applied to the standalone files and not
to the datastream.

## Is it user-visible?

Partly, and worth being precise about — I tested rather than assumed:

| Surface | `CIS` present? |
|---|---|
| oscap HTML report | **no** (0 occurrences) |
| machine-readable results XML from a scan | **yes** |
| the published datastream itself | **yes** |

No scan verdict changes. But it reaches the compliance evidence a customer
retains, and the shipped content.

## Change

Convert the five, and **close the gate behind them**: descriptive differences in
the mirror check now fail rather than being logged.

That exemption existed only because these five instances did — failing on a
difference that changes no verdict would have meant disabling the check instead
of fixing content. With the content fixed, the exemption goes, so this class
cannot drift back in silently.

## Verification

- No `CIS` values remain anywhere in the repo; datastream and standalone files
  now both report `Custom` exclusively.
- Mirror check: **zero** descriptive differences across all 8 files.
- Reintroducing a single `CIS` now **fails** the check, naming the file and
  definition — confirmed by mutation, then reverted.
- `gofmt`/`go vet` clean, `validate_checks` passes, `sds-validate` rc=0, and
  `oscap xccdf validate` reports the same 235 pre-existing errors as `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)