### PR TITLE
Remove the unused stub OVAL definition from the datastream

### DIFF
--- a/gpos/xml/scap/ssg/content/ssg-chainguard-gpos-ds.xml
+++ b/gpos/xml/scap/ssg/content/ssg-chainguard-gpos-ds.xml
@@ -17,7 +17,6 @@
       </ds:component-ref>
     </ds:checklists>
     <ds:checks>
-      <ds:component-ref id="scap_org.open-scap_cref_stub-oval.xml" xlink:href="#scap_org.open-scap_comp_stub-oval.xml"/>
       <ds:component-ref id="scap_org.open-scap_cref_PackageSignatureTest" xlink:href="#scap_org_ecomp_.packagesignaturecheck"/>
       <ds:component-ref id="scap_org.open-scap_cref_LibraryPermissionsTest" xlink:href="#scap_org_ecomp_.librarypermissions"/>
       <ds:component-ref id="scap_org.open-scap_cref_UserPasswordConfiguredTest" xlink:href="#scap_org_ecomp_.nopasswords"/>
@@ -6252,40 +6251,6 @@
         </ns0:Rule>
       </ns0:Group>
     </ns0:Benchmark>
-  </ds:component>
-  <ds:component id="scap_org.open-scap_comp_stub-oval.xml" timestamp="2025-07-16T18:40:00">
-    <oval-def:oval_definitions xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" xmlns:unix-def="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix" xmlns:ind-def="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" xmlns:lin-def="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix unix-definitions-schema.xsd http://oval.mitre.org/XMLSchema/oval-definitions-5#independent independent-definitions-schema.xsd http://oval.mitre.org/XMLSchema/oval-definitions-5#linux linux-definitions-schema.xsd http://oval.mitre.org/XMLSchema/oval-definitions-5 oval-definitions-schema.xsd http://oval.mitre.org/XMLSchema/oval-common-5 oval-common-schema.xsd">
-      <oval-def:generator>
-        <oval:product_name>OpenSCAP</oval:product_name>
-        <oval:product_version>1.3.0</oval:product_version>
-        <oval:schema_version>5.11.1</oval:schema_version>
-        <oval:timestamp>2025-07-16T18:40:00</oval:timestamp>
-      </oval-def:generator>
-      <oval-def:definitions>
-        <oval-def:definition class="compliance" id="oval:org.stub:def:1" version="1">
-          <oval-def:metadata>
-            <oval-def:title>Stub OVAL Definition</oval-def:title>
-            <oval-def:description>This is a stub OVAL definition for manual checks that
-                            do not have automated OVAL content.</oval-def:description>
-          </oval-def:metadata>
-          <oval-def:criteria>
-            <oval-def:criterion comment="This is a manual check" test_ref="oval:org.stub:tst:1"/>
-          </oval-def:criteria>
-        </oval-def:definition>
-      </oval-def:definitions>
-      <oval-def:tests>
-        <ind-def:textfilecontent54_test check="all" check_existence="all_exist" comment="Manual check placeholder" id="oval:org.stub:tst:1" version="1">
-          <ind-def:object object_ref="oval:org.stub:obj:1"/>
-        </ind-def:textfilecontent54_test>
-      </oval-def:tests>
-      <oval-def:objects>
-        <ind-def:textfilecontent54_object id="oval:org.stub:obj:1" version="1">
-          <ind-def:filepath>/dev/null</ind-def:filepath>
-          <ind-def:pattern operation="pattern match">^$</ind-def:pattern>
-          <ind-def:instance datatype="int">1</ind-def:instance>
-        </ind-def:textfilecontent54_object>
-      </oval-def:objects>
-    </oval-def:oval_definitions>
   </ds:component>
   <ds:extended-component xmlns:oscap-sce-xccdf-stream="http://open-scap.org/page/SCE_xccdf_stream" id="scap_org_ecomp_.aslr" timestamp="2016-02-23T14:36:08">
     <oscap-sce-xccdf-stream:script>#!/bin/sh


### PR DESCRIPTION
## Summary

The datastream carries a "Stub OVAL Definition" component, described as being
*"for manual checks that do not have automated OVAL content."* Remove it — it is
unreachable, it would give the wrong answer if it were reached, and the mechanism
it duplicates is both correct and already in use.

## Three reasons

**Unreachable.** Of 198 rules, 91 carry a `check-content-ref` and **none** names
the stub. Nothing has ever evaluated it.

**Wrong answer if it were reached.** Its criterion is a `textfilecontent54` test
over `/dev/null` with pattern `^$` and `check_existence="all_exist"`. Evaluated
directly:

```
$ oscap oval eval stub.xml
Definition oval:org.stub:def:1: false
```

So a rule wired to it reports **fail**. For a check whose entire point is that it
needs manual review, asserting non-compliance is worse than saying nothing.

**Not fixable into correctness.** The verdict a manual check wants is
`notchecked`, and that comes from a rule having *no check at all* — not from a
definition's result. No OVAL definition can produce it. The 107 rules here that
are manual or not-applicable already do exactly that: no `check-content-ref`, a
`<rationale>` instead, reported as `notchecked`.

## Bonus: one fewer validation warning

`oscap xccdf validate` goes **235 → 234**, and the single line that disappears is
`SRC-207-1|oval-def:definition oval:org.stub:def:1` — the stub was the only thing
that warning was about.

## Verification

- Every `xlink:href` in the datastream still resolves — no dangling references.
- `xmllint` clean, `oscap ds sds-validate` rc=0, `make validate_checks` passes.
- The mirror check's "present only in the datastream" list is now **empty**, so
  that report carries signal rather than a permanent caveat.
- Pre-existing and untouched: `./AslrCheck.sh` is referenced by a
  `check-content-ref` without a matching `cat:uri`, on `main` as well as here.

## Upstream

The component-ref is emitted by `oscap-playground`'s `has_stub_oval` metadata
flag. Filed there separately so a future regeneration does not reintroduce it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)