### PR TITLE
Add an upsert overlay op so fixtures survive base-image re-pins

### DIFF
--- a/tests/oscap-offline/internal/overlay/doc.go
+++ b/tests/oscap-offline/internal/overlay/doc.go
@@ -2,10 +2,18 @@
 // filesystem tar, producing a deterministic fixture tar.
 //
 // Each transform is an Op constructed by one of the exported helpers
-// (AppendFile, AddFile, CopyFile, Chown). Apply reads a base tar, applies the
-// ops in declaration order, and writes a PAX-format tar containing the
-// surviving base entries in their original order followed by any added entries
-// in op-declaration order.
+// (PutFile, AddFile, ReplaceFile, AppendFile, RemoveFile, CopyFile, Chown).
+// Apply reads a base tar, applies the ops in declaration order, and writes a
+// PAX-format tar containing the surviving base entries in their original order
+// followed by any added entries in op-declaration order.
+//
+// PutFile is the default choice for "this file holds this content": it replaces
+// an existing entry's content or creates the entry if absent, so a fixture using
+// it does not depend on whether the base image happens to ship the path. AddFile
+// and ReplaceFile assert the opposite preconditions and are for fixtures that
+// specifically mean to fail when the base gains or loses a path. Because PutFile
+// absorbs that drift, what the base ships is asserted directly against the base
+// tar rather than inferred from a fixture's verdict.
 //
 // Ownership and permissions are written directly into the tar headers, so the
 // resulting uid, gid and mode of every entry are determined entirely by the
@@ -13,11 +21,15 @@
 // process. Declaring root ownership (uid 0, gid 0) yields a root-owned header
 // even when the harness runs unprivileged.
 //
-// Ops that target a missing path (AppendFile, CopyFile's source, Chown) or that
-// add an already-present path (AddFile, CopyFile's destination) cause Apply to
-// return a wrapped ErrNotFound or ErrExists; AppendFile and CopyFile
-// additionally return a wrapped ErrNotRegular when the entry whose content they
-// read is not a regular file. Callers should match with errors.Is.
+// Ops that target a missing path (AppendFile, ReplaceFile, RemoveFile,
+// CopyFile's source, Chown) or that add an already-present path (AddFile,
+// CopyFile's destination) cause Apply to return a wrapped ErrNotFound or
+// ErrExists; AppendFile, ReplaceFile and CopyFile additionally return a wrapped
+// ErrNotRegular when the entry whose content they read or rewrite is not a
+// regular file. PutFile has no existence precondition, but it reaches
+// ReplaceFile's ErrNotRegular when the base holds a directory or symlink at the
+// path, and AddFile's ErrUnsafePath when the path is not clean, local and
+// relative. Callers should match with errors.Is.
 //
 // Every base member and every added path must be a clean, local, relative path
 // with no NUL byte; a member that is absolute or contains ".." causes Apply to

--- a/tests/oscap-offline/internal/overlay/overlay.go
+++ b/tests/oscap-offline/internal/overlay/overlay.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"path/filepath"
+	"slices"
 	"strings"
 )
 
@@ -103,12 +104,19 @@ func ReplaceFile(path string, content []byte) Op {
 
 // RemoveFile drops an existing entry from the produced tar. The path must
 // already exist, otherwise Apply returns a wrapped ErrNotFound.
+//
+// The name is dropped from the base ordering as well as the entry map, so a
+// later op that re-adds the same path (AddFile, or PutFile taking its create
+// branch) emits exactly one member for it, positioned with the added entries.
+// Leaving the name in the ordering would make Apply write the path twice: once
+// from the base-order loop and again from the added loop.
 func RemoveFile(path string) Op {
 	return func(p *plan) {
 		if p.require(path) == nil {
 			return
 		}
 		delete(p.byName, path)
+		p.order = slices.DeleteFunc(p.order, func(n string) bool { return n == path })
 	}
 }
 
@@ -156,12 +164,35 @@ func AddFile(path string, content []byte, mode int64, uid, gid int) Op {
 //
 // Use AddFile instead only where a fixture's point is that the path was absent,
 // so that the base gaining it should be a loud failure rather than absorbed.
+// Note that PutFile deliberately absorbs base drift rather than reporting it, so
+// it is not the place to learn what the base ships; assert that directly against
+// the base tar instead.
 //
 // mode, uid and gid apply only when the entry is created; an existing entry
 // keeps its own, since a fixture replacing content is not usually trying to
-// restate permissions.
+// restate permissions. A fixture that means to pin an existing entry's
+// attributes must say so with Chown rather than relying on these, which is why
+// no OVAL check should read permissions on a path a fixture only ever PutFiles.
+//
+// The target must be absent or a regular file: an existing directory or symlink
+// at path yields a wrapped ErrNotRegular, since replacing such an entry's
+// content cannot produce a valid tar. That matters because the base does ship
+// symlinks next to the paths fixtures mutate (etc/ssl/cert.pem and
+// etc/ssl/certs/ca-bundle.crt both alias ca-certificates.crt), so a fixture
+// targeting a CA-bundle alias hits this rather than replacing the link.
+//
+// Pairing PutFile with RemoveFile on one path is safe: RemoveFile drops the name
+// from the base ordering, so the re-add emits a single member.
 func PutFile(path string, content []byte, mode int64, uid, gid int) Op {
 	return func(p *plan) {
+		// Checked here as well as in AddFile so the guarantee is local: the
+		// replace branch below indexes byName directly and never runs AddFile's
+		// validation, relying otherwise on the invariant that every key in
+		// byName was already vetted at base ingest or by AddFile.
+		if !safePath(path) {
+			p.fail(fmt.Errorf("putting %q: %w", path, ErrUnsafePath))
+			return
+		}
 		if _, ok := p.byName[path]; ok {
 			ReplaceFile(path, content)(p)
 			return

--- a/tests/oscap-offline/internal/overlay/overlay.go
+++ b/tests/oscap-offline/internal/overlay/overlay.go
@@ -141,6 +141,35 @@ func AddFile(path string, content []byte, mode int64, uid, gid int) Op {
 	}
 }
 
+// PutFile gives path the given content whether or not it already exists:
+// replacing an existing regular file's content in place, keeping its header and
+// position in the tar, or adding a new entry with the supplied mode and
+// ownership if there is nothing there.
+//
+// This is what a fixture wants when its intent is "this file holds this
+// content", which is most of them. AddFile and ReplaceFile each assert the
+// opposite precondition, so a fixture using either is implicitly betting on
+// whether the base image ships that path — a bet that expires silently whenever
+// the base image is re-pinned. That is not hypothetical: the base gained
+// /etc/ssl/openssl.cnf, and every fixture that had been adding it started
+// failing with ErrExists before any scan ran.
+//
+// Use AddFile instead only where a fixture's point is that the path was absent,
+// so that the base gaining it should be a loud failure rather than absorbed.
+//
+// mode, uid and gid apply only when the entry is created; an existing entry
+// keeps its own, since a fixture replacing content is not usually trying to
+// restate permissions.
+func PutFile(path string, content []byte, mode int64, uid, gid int) Op {
+	return func(p *plan) {
+		if _, ok := p.byName[path]; ok {
+			ReplaceFile(path, content)(p)
+			return
+		}
+		AddFile(path, content, mode, uid, gid)(p)
+	}
+}
+
 // CopyFile adds a new regular-file entry at dst holding a copy of src's
 // content, mode and ownership, letting a fixture reproduce a base file at a
 // second path (e.g. the CA bundle a kaniko image carries under /kaniko) without

--- a/tests/oscap-offline/internal/overlay/overlay_test.go
+++ b/tests/oscap-offline/internal/overlay/overlay_test.go
@@ -585,43 +585,177 @@ func TestPutFile(t *testing.T) {
 			t.Fatalf("Apply error = %v, want errors.Is ErrUnsafePath", err)
 		}
 	})
+
+	// PutFile narrows the re-pin fragility class but does not close it: a base
+	// that ships the path as something other than a regular file still fails,
+	// with ErrNotRegular instead of ErrExists. This is not hypothetical for the
+	// etc/ssl paths fixtures mutate -- the base ships etc/ssl/cert.pem and
+	// etc/ssl/certs/ca-bundle.crt as symlinks to ca-certificates.crt -- so the
+	// boundary is pinned rather than left to be discovered by a fixture author.
+	t.Run("rejects a non-regular target", func(t *testing.T) {
+		t.Parallel()
+
+		nonRegular := []struct {
+			name string
+			hdr  tar.Header
+		}{
+			{
+				name: "base ships the path as a directory",
+				hdr:  tar.Header{Name: "etc/ssl/openssl.cnf", Typeflag: tar.TypeDir, Mode: 0o755},
+			},
+			{
+				name: "base ships the path as a symlink",
+				hdr: tar.Header{
+					Name:     "etc/ssl/cert.pem",
+					Typeflag: tar.TypeSymlink,
+					Linkname: "certs/ca-certificates.crt",
+					Mode:     0o777,
+				},
+			},
+		}
+
+		for _, tc := range nonRegular {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+				base := buildRawTar(t, tc.hdr)
+				var out bytes.Buffer
+				err := Apply(bytes.NewReader(base), []Op{PutFile(tc.hdr.Name, content, 0o644, 0, 0)}, &out)
+				if !errors.Is(err, ErrNotRegular) {
+					t.Fatalf("PutFile over %q (typeflag %q): Apply error = %v, want errors.Is ErrNotRegular",
+						tc.hdr.Name, tc.hdr.Typeflag, err)
+				}
+			})
+		}
+	})
+}
+
+// TestPutFileAfterRemoveFile pins that removing a path and then putting it back
+// emits it exactly once. RemoveFile drops the name from the entry map and from
+// the base ordering; were the ordering left alone, Apply would write the path
+// twice -- once from the base-order loop and again from the added loop --
+// producing a tar with a duplicated member that no op reports as an error.
+// PutFile's contract ("whether or not it already exists") invites this pairing,
+// so the guarantee is asserted rather than assumed.
+func TestPutFileAfterRemoveFile(t *testing.T) {
+	t.Parallel()
+
+	base := buildTar(t, map[string]fileSpec{
+		"etc/stamp": {content: []byte("original"), mode: 0o644, uid: 0, gid: 0},
+		"etc/keep":  {content: []byte("k"), mode: 0o644, uid: 0, gid: 0},
+	})
+
+	got := apply(t, base,
+		RemoveFile("etc/stamp"),
+		PutFile("etc/stamp", []byte("replacement"), 0o600, 1, 2),
+	)
+	order, byName := readEntries(t, got)
+
+	if diff := cmp.Diff([]string{"etc/keep", "etc/stamp"}, order); diff != "" {
+		t.Errorf("member order after remove-then-put (-want,+got):\n%s\nfull order: %v", diff, order)
+	}
+	// Re-added, not replaced: the entry is created fresh, so the PutFile
+	// mode/uid/gid apply rather than the removed entry's.
+	want := fileSpec{content: []byte("replacement"), mode: 0o600, uid: 1, gid: 2}
+	if diff := cmp.Diff(want, byName["etc/stamp"], cmp.AllowUnexported(fileSpec{})); diff != "" {
+		t.Errorf("re-added entry (-want,+got):\n%s", diff)
+	}
 }
 
 // TestPutFileIsDeterministic pins the property that makes fixtures reproducible:
 // the same ops over the same base produce byte-identical output, and applying
-// PutFile twice is indistinguishable from applying it once. Apply never mutates
-// its input, so nothing carries between runs — but that is worth asserting
-// rather than assuming, since the matrix shares one immutable base across every
-// subtest and a mutation would leak everywhere at once.
+// PutFile twice is indistinguishable from applying it once. The matrix shares
+// one base tar across every parallel subtest, so a PutFile whose second
+// application differed from its first would make a fixture's content depend on
+// what else ran.
+//
+// Both branches are covered, because they carry different bookkeeping: the
+// replace branch rewrites an entry in place, while the create branch appends to
+// the added list, and a repeat that appended a second time would emit the path
+// twice rather than once.
 func TestPutFileIsDeterministic(t *testing.T) {
+	t.Parallel()
+
+	content := []byte("fips = yes\n")
+
+	tests := []struct {
+		name  string
+		files map[string]fileSpec
+	}{
+		{
+			name: "replace branch: base already ships the path",
+			files: map[string]fileSpec{
+				"etc/ssl/openssl.cnf": {content: []byte("original"), mode: 0o644, uid: 0, gid: 0},
+				"etc/keep":            {content: []byte("k"), mode: 0o644, uid: 0, gid: 0},
+			},
+		},
+		{
+			name: "create branch: base lacks the path",
+			files: map[string]fileSpec{
+				"etc/keep": {content: []byte("k"), mode: 0o644, uid: 0, gid: 0},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			base := buildTar(t, tc.files)
+			put := PutFile("etc/ssl/openssl.cnf", content, 0o600, 1, 2)
+
+			once := apply(t, base, put)
+			again := apply(t, base, put)
+			if !bytes.Equal(once, again) {
+				t.Errorf("same op over the same base produced different output: %d vs %d bytes", len(once), len(again))
+			}
+
+			twice := apply(t, base, put, put)
+			if !bytes.Equal(once, twice) {
+				order, _ := readEntries(t, twice)
+				t.Errorf("applying PutFile twice differed from applying it once: %d vs %d bytes; twice order = %v",
+					len(once), len(twice), order)
+			}
+		})
+	}
+}
+
+// TestApplyReusesABaseSafely pins what actually keeps the matrix's shared base
+// tar safe to reuse across parallel subtests.
+//
+// Note what is deliberately NOT asserted here: that Apply leaves the base bytes
+// unchanged. Apply takes an io.Reader and only ever copies out of it, so it
+// cannot write to a caller's slice through that signature -- such an assertion
+// would pass regardless of what Apply did internally, and would really be
+// testing buildTar. The falsifiable properties are that per-run state is not
+// shared between calls (Apply allocates a fresh plan each time) and that ops do
+// not retain and mutate the caller's content slice (bytes.Clone in AddFile and
+// ReplaceFile). The remaining guard, cp := *hdr when copying base headers, is
+// structural: a base header never escapes Apply by reference, which is not
+// observable from outside a single call.
+func TestApplyReusesABaseSafely(t *testing.T) {
 	t.Parallel()
 
 	base := buildTar(t, map[string]fileSpec{
 		"etc/ssl/openssl.cnf": {content: []byte("original"), mode: 0o644, uid: 0, gid: 0},
-		"etc/keep":            {content: []byte("k"), mode: 0o644, uid: 0, gid: 0},
 	})
 	content := []byte("fips = yes\n")
+	contentCopy := bytes.Clone(content)
 
-	once := apply(t, base, PutFile("etc/ssl/openssl.cnf", content, 0o600, 1, 2))
-	again := apply(t, base, PutFile("etc/ssl/openssl.cnf", content, 0o600, 1, 2))
-	if !bytes.Equal(once, again) {
-		t.Errorf("same ops over the same base produced different output: %d vs %d bytes", len(once), len(again))
+	// Two runs over one base: were any per-run state shared, the second would
+	// see the first's mutations.
+	first := apply(t, base, PutFile("etc/ssl/openssl.cnf", content, 0o600, 0, 0))
+	second := apply(t, base, PutFile("etc/ssl/openssl.cnf", content, 0o600, 0, 0))
+	if !bytes.Equal(first, second) {
+		t.Errorf("second Apply over the same base differed: %d vs %d bytes", len(first), len(second))
 	}
 
-	twice := apply(t, base,
-		PutFile("etc/ssl/openssl.cnf", content, 0o600, 1, 2),
-		PutFile("etc/ssl/openssl.cnf", content, 0o600, 1, 2),
+	// The caller's content slice must not be retained by the op and then mutated
+	// by a later one, which would change what an earlier fixture asserted.
+	_ = apply(t, base,
+		PutFile("etc/ssl/openssl.cnf", content, 0o600, 0, 0),
+		AppendFile("etc/ssl/openssl.cnf", []byte("appended")),
 	)
-	if !bytes.Equal(once, twice) {
-		t.Errorf("applying PutFile twice differed from applying it once: %d vs %d bytes", len(once), len(twice))
-	}
-
-	// The base bytes must be untouched, or the shared base would drift across subtests.
-	pristine := buildTar(t, map[string]fileSpec{
-		"etc/ssl/openssl.cnf": {content: []byte("original"), mode: 0o644, uid: 0, gid: 0},
-		"etc/keep":            {content: []byte("k"), mode: 0o644, uid: 0, gid: 0},
-	})
-	if !bytes.Equal(base, pristine) {
-		t.Error("Apply mutated the base tar it was given")
+	if !bytes.Equal(content, contentCopy) {
+		t.Errorf("op mutated the caller's content slice: got %q, want %q", content, contentCopy)
 	}
 }

--- a/tests/oscap-offline/internal/overlay/overlay_test.go
+++ b/tests/oscap-offline/internal/overlay/overlay_test.go
@@ -520,3 +520,108 @@ func TestApplyNoOps(t *testing.T) {
 		t.Errorf("no-op Apply changed entries (-want,+got):\n%s", diff)
 	}
 }
+
+// TestPutFile covers both directions of the upsert, plus the property that
+// motivated it: the same op works whether or not the base ships the path, so a
+// fixture stops depending on that and stops breaking when the base is re-pinned.
+func TestPutFile(t *testing.T) {
+	t.Parallel()
+
+	content := []byte("fips = yes\n")
+
+	t.Run("replaces an existing file and keeps its header", func(t *testing.T) {
+		t.Parallel()
+		base := buildTar(t, map[string]fileSpec{
+			"etc/ssl/openssl.cnf": {content: randBytes(40), mode: 0o444, uid: 7, gid: 9},
+		})
+		got := apply(t, base, PutFile("etc/ssl/openssl.cnf", content, 0o600, 0, 0))
+		_, byName := readEntries(t, got)
+		// mode/uid/gid come from the existing entry, not the PutFile arguments.
+		want := fileSpec{content: content, mode: 0o444, uid: 7, gid: 9}
+		if diff := cmp.Diff(want, byName["etc/ssl/openssl.cnf"], cmp.AllowUnexported(fileSpec{})); diff != "" {
+			t.Errorf("PutFile over an existing entry (-want,+got):\n%s", diff)
+		}
+	})
+
+	t.Run("adds the file when the base does not have it", func(t *testing.T) {
+		t.Parallel()
+		base := buildTar(t, map[string]fileSpec{
+			"etc/other": {content: []byte("x"), mode: 0o644, uid: 0, gid: 0},
+		})
+		got := apply(t, base, PutFile("etc/ssl/openssl.cnf", content, 0o600, 3, 4))
+		_, byName := readEntries(t, got)
+		want := fileSpec{content: content, mode: 0o600, uid: 3, gid: 4}
+		if diff := cmp.Diff(want, byName["etc/ssl/openssl.cnf"], cmp.AllowUnexported(fileSpec{})); diff != "" {
+			t.Errorf("PutFile creating an entry (-want,+got):\n%s", diff)
+		}
+	})
+
+	t.Run("same op succeeds against both bases", func(t *testing.T) {
+		t.Parallel()
+		// The regression this exists for: AddFile fails on the with-file base
+		// and ReplaceFile fails on the without-file one, so neither can express
+		// a fixture that must survive the base gaining or losing the path.
+		withFile := buildTar(t, map[string]fileSpec{
+			"etc/ssl/openssl.cnf": {content: []byte("old"), mode: 0o644, uid: 0, gid: 0},
+		})
+		without := buildTar(t, map[string]fileSpec{
+			"etc/keep": {content: []byte("k"), mode: 0o644, uid: 0, gid: 0},
+		})
+		for name, base := range map[string][]byte{"base has the file": withFile, "base lacks it": without} {
+			var out bytes.Buffer
+			if err := Apply(bytes.NewReader(base), []Op{PutFile("etc/ssl/openssl.cnf", content, 0o644, 0, 0)}, &out); err != nil {
+				t.Errorf("%s: Apply = %v, want nil", name, err)
+			}
+		}
+	})
+
+	t.Run("rejects an unsafe path", func(t *testing.T) {
+		t.Parallel()
+		base := buildTar(t, map[string]fileSpec{
+			"etc/keep": {content: []byte("k"), mode: 0o644, uid: 0, gid: 0},
+		})
+		var out bytes.Buffer
+		if err := Apply(bytes.NewReader(base), []Op{PutFile("../escape", content, 0o644, 0, 0)}, &out); !errors.Is(err, ErrUnsafePath) {
+			t.Fatalf("Apply error = %v, want errors.Is ErrUnsafePath", err)
+		}
+	})
+}
+
+// TestPutFileIsDeterministic pins the property that makes fixtures reproducible:
+// the same ops over the same base produce byte-identical output, and applying
+// PutFile twice is indistinguishable from applying it once. Apply never mutates
+// its input, so nothing carries between runs — but that is worth asserting
+// rather than assuming, since the matrix shares one immutable base across every
+// subtest and a mutation would leak everywhere at once.
+func TestPutFileIsDeterministic(t *testing.T) {
+	t.Parallel()
+
+	base := buildTar(t, map[string]fileSpec{
+		"etc/ssl/openssl.cnf": {content: []byte("original"), mode: 0o644, uid: 0, gid: 0},
+		"etc/keep":            {content: []byte("k"), mode: 0o644, uid: 0, gid: 0},
+	})
+	content := []byte("fips = yes\n")
+
+	once := apply(t, base, PutFile("etc/ssl/openssl.cnf", content, 0o600, 1, 2))
+	again := apply(t, base, PutFile("etc/ssl/openssl.cnf", content, 0o600, 1, 2))
+	if !bytes.Equal(once, again) {
+		t.Errorf("same ops over the same base produced different output: %d vs %d bytes", len(once), len(again))
+	}
+
+	twice := apply(t, base,
+		PutFile("etc/ssl/openssl.cnf", content, 0o600, 1, 2),
+		PutFile("etc/ssl/openssl.cnf", content, 0o600, 1, 2),
+	)
+	if !bytes.Equal(once, twice) {
+		t.Errorf("applying PutFile twice differed from applying it once: %d vs %d bytes", len(once), len(twice))
+	}
+
+	// The base bytes must be untouched, or the shared base would drift across subtests.
+	pristine := buildTar(t, map[string]fileSpec{
+		"etc/ssl/openssl.cnf": {content: []byte("original"), mode: 0o644, uid: 0, gid: 0},
+		"etc/keep":            {content: []byte("k"), mode: 0o644, uid: 0, gid: 0},
+	})
+	if !bytes.Equal(base, pristine) {
+		t.Error("Apply mutated the base tar it was given")
+	}
+}

--- a/tests/oscap-offline/internal/scan/base_composition_test.go
+++ b/tests/oscap-offline/internal/scan/base_composition_test.go
@@ -1,0 +1,234 @@
+package scan_test
+
+import (
+	"archive/tar"
+	"bytes"
+	"errors"
+	"io"
+	"os"
+	"testing"
+
+	"github.com/chainguard-dev/stigs/tests/oscap-offline/internal/rootfs"
+	"github.com/chainguard-dev/stigs/tests/oscap-offline/internal/scan"
+)
+
+// Every fixture in the offline matrix rests on premises about what the pinned
+// wolfi-base ships: a fixture that appends to etc/shadow needs it to exist, and
+// a fixture asserting "an unmodified image fails this rule" needs the base to
+// lack the pieces that would make it pass. Nothing used to check those premises
+// directly -- they were only implied by the ops a fixture declared, so a
+// re-pinned base could change one and either break the matrix with an error far
+// from the cause, or, worse, quietly leave a fixture asserting less than its
+// name claims.
+//
+// overlay.PutFile made the second failure mode the more likely one. It absorbs
+// the presence or absence of a path by design, which is what stops a re-pin from
+// erroring, but it also means a fixture can no longer be relied on to notice
+// drift on its own. This file is where that drift is caught instead: it asserts
+// base composition directly, so a re-pin that moves the ground under the matrix
+// fails here, naming the path and the fixture that depended on it, rather than
+// surfacing as a mystery verdict flip.
+//
+// It needs only a registry pull, not a container runtime or the datastream, so
+// it runs in more environments than the matrix itself.
+
+// basePathExpectation is one premise about the base image, paired with the
+// reason it matters so a failure explains itself.
+type basePathExpectation struct {
+	path string
+	why  string
+}
+
+// basePresent lists paths the fixtures require the base to ship, because an op
+// with an existence precondition targets them (AppendFile, ReplaceFile,
+// RemoveFile, Chown, or CopyFile's source). A re-pin dropping one of these
+// breaks the matrix with a wrapped ErrNotFound.
+var basePresent = []basePathExpectation{
+	{"etc/ssl/certs/ca-certificates.crt", "caBundlePath: AppendFile tampers it; CopyFile reads it for the /kaniko fixtures"},
+	{"etc/ssl/certs/.ca-certificates.crt.sha256", "caStampPath: ReplaceFile writes wrong/malformed stamps, RemoveFile drops it"},
+	{"usr/lib/apk/db/installed", "AppendFile records apk package stanzas for the FIPS, remote-access and permissions fixtures"},
+	{"etc/apk/repositories", "AppendFile adds the plain-HTTP and commented-repo lines for PackageSignature"},
+	{"etc/shadow", "AppendFile adds the active, empty and locked password entries for UserPasswordConfigured and NoUsers"},
+	{"var/log", "Chown makes it non-root for the VarLogPermissions fail fixture"},
+}
+
+// baseAbsent lists paths whose ABSENCE gives a fixture its discriminating
+// power. These are the assertions that would otherwise degrade silently: if the
+// base gained one, the fixture depending on its absence would keep passing while
+// testing less, because PutFile absorbs the difference instead of erroring.
+var baseAbsent = []basePathExpectation{
+	{"etc/ssl/fipsmodule.cnf", "detect_openssl/fail_clean_no_fips declares no ops: an unmodified base must fail DetectOpenSsl, whose tst:1 is at_least_one_exists on this path"},
+	{"etc/ssh/ssh_config", "the ssh_config drop-in sourcing check (tst:21) must not be satisfiable by an unmodified base"},
+	{"etc/ssh/sshd_config", "the sshd_config drop-in sourcing check (tst:22) must not be satisfiable by an unmodified base"},
+	{"etc/ssh/ssh_config.d/10-ssh-fips.conf", "the client FIPS drop-in criteria (tst:9-12) must not be satisfiable by an unmodified base"},
+	{"etc/ssh/sshd_config.d/10-sshd-fips.conf", "the server FIPS drop-in criteria (tst:13-20) must not be satisfiable by an unmodified base"},
+	{"etc/ssl/certs/java/cacerts", "CertificateAudit tst:5 is none_exist on the Java truststore; certificate_audit/pass_java_truststore is the only fixture exercising the present-and-matching branch, so it must synthesize the pair rather than inherit one"},
+	{"etc/ssl/certs/java/.cacerts.sha256", "javaStampPath: as above, the truststore stamp must come from the fixture"},
+	{"kaniko/ssl/certs/ca-certificates.crt", "kanikoCABundlePath is a CopyFile destination, which requires the path to be absent"},
+	{"kaniko/ssl/certs/.ca-certificates.crt.sha256", "kanikoCAStampPath: as above, and CertificateAudit tst:13 is none_exist on it"},
+}
+
+// basePutFileTargets lists every path the matrix reaches with overlay.PutFile.
+// PutFile tolerates the path being absent or a regular file, but NOT a
+// directory or symlink: those fail with a wrapped ErrNotRegular, which is the
+// same re-pin breakage shape PutFile was introduced to eliminate. That is a real
+// risk for these paths rather than a theoretical one, because the base ships
+// etc/ssl/cert.pem and etc/ssl/certs/ca-bundle.crt as symlinks to
+// ca-certificates.crt, so the etc/ssl tree demonstrably does contain aliases.
+//
+// etc/ssl/openssl.cnf is deliberately in this list and in neither of the two
+// above: it is the path that drifted (absent before 2026-09-02, shipped after),
+// so pinning it either way would just re-create the bet PutFile removed. What
+// must hold is that it never becomes a non-regular entry.
+var basePutFileTargets = []string{
+	"etc/ssl/openssl.cnf",
+	"etc/ssl/fipsmodule.cnf",
+	"etc/ssh/ssh_config",
+	"etc/ssh/sshd_config",
+	"etc/ssh/ssh_config.d/10-ssh-fips.conf",
+	"etc/ssh/sshd_config.d/10-sshd-fips.conf",
+	"etc/ssl/certs/java/cacerts",
+	"etc/ssl/certs/java/.cacerts.sha256",
+}
+
+// baseFIPSPackages are the apk package names DetectOpenSsl requires (tst:3 and
+// tst:4). The base must have neither, or detect_openssl/fail_clean_no_fips stops
+// being a control.
+var baseFIPSPackages = []string{
+	"openssl-config-fipshardened",
+	"openssl-provider-fips",
+}
+
+// baseMembers exports the pinned base image and indexes its members by name.
+// Only the registry is required, so a prerequisite gap skips in local dev and
+// fails under OSCAP_OFFLINE_REQUIRE, matching the matrix's policy.
+func baseMembers(t *testing.T) (map[string]tar.Header, []byte) {
+	t.Helper()
+
+	require := requireScans()
+
+	repoRoot, ok := findUp(t, scan.DefaultDatastreamRelPath)
+	if !ok {
+		skipOrFatal(t, require, "datastream %q not found above working dir", scan.DefaultDatastreamRelPath)
+		return nil, nil
+	}
+
+	basePath, err := rootfs.New().EnsureBaseTar(t.Context(), baseRef(t, repoRoot), t.TempDir())
+	if err != nil {
+		skipOrFatal(t, require, "cannot export pinned wolfi-base (offline?): %v", err)
+		return nil, nil
+	}
+	baseBytes, err := os.ReadFile(basePath)
+	if err != nil {
+		t.Fatalf("reading exported base tar %q: %v", basePath, err)
+	}
+
+	members := make(map[string]tar.Header)
+	var apkDB []byte
+	tr := tar.NewReader(bytes.NewReader(baseBytes))
+	for {
+		hdr, err := tr.Next()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			t.Fatalf("reading base tar %q: %v", basePath, err)
+		}
+		members[hdr.Name] = *hdr
+		if hdr.Name == "usr/lib/apk/db/installed" {
+			if apkDB, err = io.ReadAll(tr); err != nil {
+				t.Fatalf("reading apk db from base tar: %v", err)
+			}
+		}
+	}
+	if len(members) == 0 {
+		t.Fatalf("base tar %q has no members; the assertions below would be vacuous", basePath)
+	}
+	return members, apkDB
+}
+
+// typeName renders a tar typeflag for failure messages.
+func typeName(flag byte) string {
+	switch flag {
+	case tar.TypeReg:
+		return "regular file"
+	case tar.TypeDir:
+		return "directory"
+	case tar.TypeSymlink:
+		return "symlink"
+	case tar.TypeLink:
+		return "hard link"
+	default:
+		return "typeflag " + string(rune(flag))
+	}
+}
+
+// TestBaseImageComposition asserts the premises the offline fixture matrix rests
+// on, directly against the pinned base image. A failure here means a re-pin
+// changed the ground under a fixture: the message names the path, what changed,
+// and which fixture or OVAL test depended on it.
+func TestBaseImageComposition(t *testing.T) {
+	t.Parallel()
+
+	if testing.Short() {
+		t.Skip("skipping base image composition check in -short mode")
+	}
+
+	members, apkDB := baseMembers(t)
+	if members == nil {
+		// baseMembers skips or fatals on a prerequisite gap; defensive only.
+		t.Skip("base image unavailable; skipping composition check")
+	}
+
+	t.Run("paths the fixtures require", func(t *testing.T) {
+		t.Parallel()
+		for _, want := range basePresent {
+			hdr, ok := members[want.path]
+			if !ok {
+				t.Errorf("base no longer ships %q, which the matrix depends on.\n  needed because: %s\n  a fixture op targeting it will now fail with overlay.ErrNotFound", want.path, want.why)
+				continue
+			}
+			// Content-mutating ops need a regular file; var/log is only chowned,
+			// so a directory is correct there.
+			if hdr.Typeflag != tar.TypeReg && hdr.Typeflag != tar.TypeDir {
+				t.Errorf("base ships %q as a %s, not a regular file or directory.\n  needed because: %s", want.path, typeName(hdr.Typeflag), want.why)
+			}
+		}
+	})
+
+	t.Run("paths whose absence the fixtures rely on", func(t *testing.T) {
+		t.Parallel()
+		for _, want := range baseAbsent {
+			hdr, ok := members[want.path]
+			if !ok {
+				continue
+			}
+			t.Errorf("base now ships %q (%s), which a fixture assumed absent.\n  relied on because: %s\n  the fixture will still pass, but it is no longer testing what its name claims -- re-check it rather than deleting this row", want.path, typeName(hdr.Typeflag), want.why)
+		}
+	})
+
+	t.Run("PutFile targets are absent or regular files", func(t *testing.T) {
+		t.Parallel()
+		for _, path := range basePutFileTargets {
+			hdr, ok := members[path]
+			if !ok {
+				continue // absent is fine: PutFile creates it
+			}
+			if hdr.Typeflag != tar.TypeReg {
+				t.Errorf("base ships %q as a %s; overlay.PutFile can only create or replace a regular file, so every fixture touching it now fails with overlay.ErrNotRegular.\n  fix the fixture (RemoveFile then PutFile, or target the link's destination) rather than relaxing this check", path, typeName(hdr.Typeflag))
+			}
+		}
+	})
+
+	t.Run("no FIPS packages installed", func(t *testing.T) {
+		t.Parallel()
+		if apkDB == nil {
+			t.Fatal("apk db absent from base tar; the FIPS-package assertion would be vacuous")
+		}
+		for _, pkg := range baseFIPSPackages {
+			if bytes.Contains(apkDB, []byte("\nP:"+pkg+"\n")) {
+				t.Errorf("base now records apk package %q as installed.\n  detect_openssl/fail_clean_no_fips declares no ops and asserts an unmodified base FAILS DetectOpenSsl; with the FIPS packages present that control weakens or flips", pkg)
+			}
+		}
+	})
+}

--- a/tests/oscap-offline/internal/scan/fixtures_test.go
+++ b/tests/oscap-offline/internal/scan/fixtures_test.go
@@ -461,8 +461,8 @@ var (
 // them. Returned fresh each call so callers may append without aliasing.
 func fipsCoreOps() []overlay.Op {
 	return []overlay.Op{
-		overlay.AddFile("etc/ssl/fipsmodule.cnf", fipsModuleCnf, 0o644, 0, 0),
-		overlay.AddFile("etc/ssl/openssl.cnf", opensslCnf, 0o644, 0, 0),
+		overlay.PutFile("etc/ssl/fipsmodule.cnf", fipsModuleCnf, 0o644, 0, 0),
+		overlay.PutFile("etc/ssl/openssl.cnf", opensslCnf, 0o644, 0, 0),
 		overlay.AppendFile("usr/lib/apk/db/installed", apkFIPSPackages),
 		overlay.AppendFile("usr/lib/apk/db/installed", apkOpenSSHClientStanza),
 		overlay.AppendFile("usr/lib/apk/db/installed", apkOpenSSHServerStanza),
@@ -476,10 +476,10 @@ func fipsCoreOps() []overlay.Op {
 // each call so callers may append without aliasing.
 func fipsPresentOps() []overlay.Op {
 	return append(fipsCoreOps(),
-		overlay.AddFile("etc/ssh/ssh_config", sshConfigMain, 0o644, 0, 0),
-		overlay.AddFile("etc/ssh/sshd_config", sshdConfigMain, 0o644, 0, 0),
-		overlay.AddFile("etc/ssh/ssh_config.d/10-ssh-fips.conf", sshFipsClientConf, 0o644, 0, 0),
-		overlay.AddFile("etc/ssh/sshd_config.d/10-sshd-fips.conf", sshFipsServerConf, 0o644, 0, 0),
+		overlay.PutFile("etc/ssh/ssh_config", sshConfigMain, 0o644, 0, 0),
+		overlay.PutFile("etc/ssh/sshd_config", sshdConfigMain, 0o644, 0, 0),
+		overlay.PutFile("etc/ssh/ssh_config.d/10-ssh-fips.conf", sshFipsClientConf, 0o644, 0, 0),
+		overlay.PutFile("etc/ssh/sshd_config.d/10-sshd-fips.conf", sshFipsServerConf, 0o644, 0, 0),
 	)
 }
 
@@ -627,8 +627,8 @@ func matrixCases() []matrixCase {
 			// only fixture exercising the "present and matching" OR branch.
 			name: "certificate_audit/pass_java_truststore",
 			ops: []overlay.Op{
-				overlay.AddFile(javaTrustStorePath, javaTrustStore, 0o444, 0, 0),
-				overlay.AddFile(javaStampPath, javaStamp(javaTrustStore), 0o444, 0, 0),
+				overlay.PutFile(javaTrustStorePath, javaTrustStore, 0o444, 0, 0),
+				overlay.PutFile(javaStampPath, javaStamp(javaTrustStore), 0o444, 0, 0),
 			},
 			containerVars: []string{"SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt"},
 			want:          map[string]results.Result{ruleCertificateAudit: results.Pass},
@@ -638,8 +638,8 @@ func matrixCases() []matrixCase {
 			// for different content, i.e. a truststore modified in place.
 			name: "certificate_audit/fail_java_wrong_stamp",
 			ops: []overlay.Op{
-				overlay.AddFile(javaTrustStorePath, javaTrustStore, 0o444, 0, 0),
-				overlay.AddFile(javaStampPath, javaStamp([]byte("other content")), 0o444, 0, 0),
+				overlay.PutFile(javaTrustStorePath, javaTrustStore, 0o444, 0, 0),
+				overlay.PutFile(javaStampPath, javaStamp([]byte("other content")), 0o444, 0, 0),
 			},
 			containerVars: []string{"SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt"},
 			want:          map[string]results.Result{ruleCertificateAudit: results.Fail},
@@ -650,7 +650,7 @@ func matrixCases() []matrixCase {
 			// truststore, it just cannot be verified.
 			name: "certificate_audit/fail_java_missing_stamp",
 			ops: []overlay.Op{
-				overlay.AddFile(javaTrustStorePath, javaTrustStore, 0o444, 0, 0),
+				overlay.PutFile(javaTrustStorePath, javaTrustStore, 0o444, 0, 0),
 			},
 			containerVars: []string{"SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt"},
 			want:          map[string]results.Result{ruleCertificateAudit: results.Fail},
@@ -804,9 +804,18 @@ func matrixCases() []matrixCase {
 		},
 
 		// DetectOpenSsl is inverted: a vanilla wolfi-base lacks the OpenSSL FIPS
-		// module config, packages, and OpenSSH FIPS drop-ins this rule requires, so
-		// the CLEAN tree FAILS. The "pass" fixtures synthesize every required file
-		// and package record via fipsPresentOps.
+		// module config, the FIPS apk packages, and the OpenSSH FIPS drop-ins this
+		// rule requires, so the CLEAN tree FAILS. The "pass" fixtures synthesize
+		// every required file and package record via fipsPresentOps.
+		//
+		// The base does now ship /etc/ssl/openssl.cnf, which it did not when these
+		// fixtures were written, so that file's absence is no longer part of why
+		// the clean tree fails. fail_clean_no_fips is deliberately op-free: it
+		// asserts that an *unmodified* image fails, which is what a real scan of
+		// wolfi-base yields. That means its discriminating power tracks whatever
+		// the base ships — but it degrades loudly, not silently: if the base ever
+		// gained the FIPS module config and packages, this row would flip to pass
+		// and fail the suite rather than quietly assert less.
 		{
 			name: "detect_openssl/fail_clean_no_fips",
 			want: map[string]results.Result{ruleDetectOpenSsl: results.Fail},
@@ -842,8 +851,8 @@ func matrixCases() []matrixCase {
 			// irrelevant — the rule fails purely on the OpenSSL package dimension.
 			name: "detect_openssl/fail_doc_subpackage_only",
 			ops: []overlay.Op{
-				overlay.AddFile("etc/ssl/fipsmodule.cnf", fipsModuleCnf, 0o644, 0, 0),
-				overlay.AddFile("etc/ssl/openssl.cnf", opensslCnf, 0o644, 0, 0),
+				overlay.PutFile("etc/ssl/fipsmodule.cnf", fipsModuleCnf, 0o644, 0, 0),
+				overlay.PutFile("etc/ssl/openssl.cnf", opensslCnf, 0o644, 0, 0),
 				overlay.AppendFile("usr/lib/apk/db/installed", apkFIPSPackagesDocSubpkg),
 			},
 			want: map[string]results.Result{ruleDetectOpenSsl: results.Fail},
@@ -855,8 +864,8 @@ func matrixCases() []matrixCase {
 			// fails. Isolates the SSH drop-in file-existence dimension.
 			name: "detect_openssl/fail_missing_ssh_fips_conf",
 			ops: append(fipsCoreOps(),
-				overlay.AddFile("etc/ssh/ssh_config", sshConfigMain, 0o644, 0, 0),
-				overlay.AddFile("etc/ssh/sshd_config", sshdConfigMain, 0o644, 0, 0),
+				overlay.PutFile("etc/ssh/ssh_config", sshConfigMain, 0o644, 0, 0),
+				overlay.PutFile("etc/ssh/sshd_config", sshdConfigMain, 0o644, 0, 0),
 			),
 			want: map[string]results.Result{ruleDetectOpenSsl: results.Fail},
 		},
@@ -867,10 +876,10 @@ func matrixCases() []matrixCase {
 			// dimension (and proves the server branch is enforced when installed).
 			name: "detect_openssl/fail_wrong_ssh_fips_value",
 			ops: append(fipsCoreOps(),
-				overlay.AddFile("etc/ssh/ssh_config", sshConfigMain, 0o644, 0, 0),
-				overlay.AddFile("etc/ssh/sshd_config", sshdConfigMain, 0o644, 0, 0),
-				overlay.AddFile("etc/ssh/ssh_config.d/10-ssh-fips.conf", sshFipsClientConf, 0o644, 0, 0),
-				overlay.AddFile("etc/ssh/sshd_config.d/10-sshd-fips.conf", sshFipsServerConfWrongCipher, 0o644, 0, 0),
+				overlay.PutFile("etc/ssh/ssh_config", sshConfigMain, 0o644, 0, 0),
+				overlay.PutFile("etc/ssh/sshd_config", sshdConfigMain, 0o644, 0, 0),
+				overlay.PutFile("etc/ssh/ssh_config.d/10-ssh-fips.conf", sshFipsClientConf, 0o644, 0, 0),
+				overlay.PutFile("etc/ssh/sshd_config.d/10-sshd-fips.conf", sshFipsServerConfWrongCipher, 0o644, 0, 0),
 			),
 			want: map[string]results.Result{ruleDetectOpenSsl: results.Fail},
 		},
@@ -881,8 +890,8 @@ func matrixCases() []matrixCase {
 			// drop-in-wiring dimension — a drop-in that is never sourced is inert.
 			name: "detect_openssl/fail_ssh_config_missing_include",
 			ops: append(fipsCoreOps(),
-				overlay.AddFile("etc/ssh/ssh_config.d/10-ssh-fips.conf", sshFipsClientConf, 0o644, 0, 0),
-				overlay.AddFile("etc/ssh/sshd_config.d/10-sshd-fips.conf", sshFipsServerConf, 0o644, 0, 0),
+				overlay.PutFile("etc/ssh/ssh_config.d/10-ssh-fips.conf", sshFipsClientConf, 0o644, 0, 0),
+				overlay.PutFile("etc/ssh/sshd_config.d/10-sshd-fips.conf", sshFipsServerConf, 0o644, 0, 0),
 			),
 			want: map[string]results.Result{ruleDetectOpenSsl: results.Fail},
 		},
@@ -893,12 +902,12 @@ func matrixCases() []matrixCase {
 			// and no server drop-in. This mirrors the cgr.dev go-fips image.
 			name: "detect_openssl/pass_client_only_no_server",
 			ops: []overlay.Op{
-				overlay.AddFile("etc/ssl/fipsmodule.cnf", fipsModuleCnf, 0o644, 0, 0),
-				overlay.AddFile("etc/ssl/openssl.cnf", opensslCnf, 0o644, 0, 0),
+				overlay.PutFile("etc/ssl/fipsmodule.cnf", fipsModuleCnf, 0o644, 0, 0),
+				overlay.PutFile("etc/ssl/openssl.cnf", opensslCnf, 0o644, 0, 0),
 				overlay.AppendFile("usr/lib/apk/db/installed", apkFIPSPackages),
 				overlay.AppendFile("usr/lib/apk/db/installed", apkOpenSSHClientStanza),
-				overlay.AddFile("etc/ssh/ssh_config", sshConfigMain, 0o644, 0, 0),
-				overlay.AddFile("etc/ssh/ssh_config.d/10-ssh-fips.conf", sshFipsClientConf, 0o644, 0, 0),
+				overlay.PutFile("etc/ssh/ssh_config", sshConfigMain, 0o644, 0, 0),
+				overlay.PutFile("etc/ssh/ssh_config.d/10-ssh-fips.conf", sshFipsClientConf, 0o644, 0, 0),
 			},
 			want: map[string]results.Result{ruleDetectOpenSsl: results.Pass},
 		},
@@ -907,8 +916,8 @@ func matrixCases() []matrixCase {
 			// the rule PASSES on the OpenSSL criteria alone with no ssh files present.
 			name: "detect_openssl/pass_no_openssh_installed",
 			ops: []overlay.Op{
-				overlay.AddFile("etc/ssl/fipsmodule.cnf", fipsModuleCnf, 0o644, 0, 0),
-				overlay.AddFile("etc/ssl/openssl.cnf", opensslCnf, 0o644, 0, 0),
+				overlay.PutFile("etc/ssl/fipsmodule.cnf", fipsModuleCnf, 0o644, 0, 0),
+				overlay.PutFile("etc/ssl/openssl.cnf", opensslCnf, 0o644, 0, 0),
 				overlay.AppendFile("usr/lib/apk/db/installed", apkFIPSPackages),
 			},
 			want: map[string]results.Result{ruleDetectOpenSsl: results.Pass},
@@ -920,8 +929,8 @@ func matrixCases() []matrixCase {
 			// FAILS — proving the server gate enforces when openssh-server is present.
 			name: "detect_openssl/fail_server_installed_missing_config",
 			ops: []overlay.Op{
-				overlay.AddFile("etc/ssl/fipsmodule.cnf", fipsModuleCnf, 0o644, 0, 0),
-				overlay.AddFile("etc/ssl/openssl.cnf", opensslCnf, 0o644, 0, 0),
+				overlay.PutFile("etc/ssl/fipsmodule.cnf", fipsModuleCnf, 0o644, 0, 0),
+				overlay.PutFile("etc/ssl/openssl.cnf", opensslCnf, 0o644, 0, 0),
 				overlay.AppendFile("usr/lib/apk/db/installed", apkFIPSPackages),
 				overlay.AppendFile("usr/lib/apk/db/installed", apkOpenSSHServerStanza),
 			},


### PR DESCRIPTION
> Unblocks #173. That PR is red and the cron will hit the same wall tomorrow, so
> this wants to land before or with it.

## What broke

The offline matrix failed on #173, the daily base-image re-pin. Every
`detect_openssl` fixture errored before any scan ran:

```
overlay apply: adding "etc/ssl/openssl.cnf": path already exists
```

The newer `wolfi-base` ships `/etc/ssl/openssl.cnf`; the previously pinned image
did not. Confirmed by inspecting both:

| base | `etc/ssl/openssl.cnf` |
|---|---|
| `7e62cecd` (main) | 0 occurrences |
| `103eb3f4` (#173) | 1 occurrence |

Nothing about the datastream or the checks was wrong — `End-to-end scan`, the
mirror check, the lint gate and the sidecar guard all passed on that PR.

## The defect is an API gap, not a bad fixture

No overlay op could express "this file holds this content":

| op | precondition |
|---|---|
| `AddFile` | path must **not** exist |
| `ReplaceFile` | path **must** exist |
| `AppendFile` | path must exist |

So every fixture was implicitly betting on whether the base image ships a path,
and the bet expired silently whenever the base was re-pinned. `openssl.cnf` just
went first — `fipsmodule.cnf`, `ssh_config`, `sshd_config` and the FIPS drop-ins
were all equally exposed.

Swapping to `ReplaceFile` would only invert the bet: it would break the moment a
base *dropped* a path.

## Change

`PutFile` replaces an existing entry's content in place — keeping its header and
position in the tar — or creates one if absent. `mode`/`uid`/`gid` apply only on
creation, since a fixture replacing content is not usually restating permissions.

All 29 `AddFile` calls in the fixture matrix move onto it. Each means "this file
holds this content"; none relied on the absence precondition for its meaning. The
fixtures that *do* test absence express it by **omitting** the file
(`fail_missing_ssh_fips_conf` leaves out the drop-ins, `fail_java_missing_stamp`
adds a truststore and no stamp), so that behaviour is unchanged. `AddFile` stays
for cases where a base gaining a path *should* fail loudly, and remains in use by
`CopyFile` and `PutFile`.

## Verified causally, not just green

- Against #173's base, the converted fixtures pass — and reverting them to
  `AddFile` reproduces the exact `path already exists` error.
- Against main's base they also pass, so this is not a swap of one bet for the
  other.
- Full matrix green: 47 rows, 11 of them `detect_openssl`, 0 failures.
  `gofmt`/`vet` clean, mirror check unaffected.

`TestPutFile` covers both directions plus the property that motivated it: the
same op applies cleanly whether or not the base ships the path.

## Idempotency

`TestPutFileIsDeterministic` asserts the same ops over the same base give
byte-identical output, and that applying `PutFile` twice equals applying it once.
It runs over **both** branches, which matter separately: replace rewrites an entry
in place, while create appends to the added list, so a repeat that appended twice
would emit the path twice rather than once.

This matters because the matrix shares one base across every parallel subtest: a
`PutFile` whose second application differed from its first would make a fixture's
content depend on what else ran.

An earlier draft of this PR also asserted that **`Apply` leaves the base bytes
untouched**, and billed that as the load-bearing guarantee. That was wrong, and it
is worth stating rather than quietly dropping: `Apply` takes an `io.Reader` and
only ever copies out of it, so it cannot write to a caller's slice through that
signature at all. The assertion could not fail whatever `Apply` did internally —
it really tested `buildTar`'s determinism. `TestApplyReusesABaseSafely` asserts
the properties that genuinely can fail instead (no per-run state shared between
calls; ops not retaining and then mutating the caller's content slice) and
records that the remaining guard, `cp := *hdr`, is structural and not observable
from outside a single `Apply` call.

## One stale premise found along the way

`detect_openssl/fail_clean_no_fips` has no ops — it is the "an unmodified image
fails this rule" control. Its assertion is still correct, but its comment claimed
the vanilla base lacks the OpenSSL FIPS module config, and the base now ships
`openssl.cnf`. What is actually true of the new base:

| | |
|---|---|
| `etc/ssl/openssl.cnf` | present (new) |
| `etc/ssl/fipsmodule.cnf` | absent |
| FIPS apk packages | 0 installed |

So it still fails, on the module config and the packages; `openssl.cnf`'s absence
is simply no longer part of why. Comment corrected, and the fixture deliberately
left op-free: it degrades **loudly**, not silently — if the base ever gained the
FIPS pieces, that row would flip to pass and fail the suite rather than quietly
assert less. Worth noting `AddFile` never protected that fixture either, since it
calls no ops, so this exposure was independent of the change.

## Added in review

`b9e6db2` — **a duplicate tar member on remove-then-re-add.** `RemoveFile` dropped
a path from the entry map but left its name in the base ordering, so a later op
re-adding it made `Apply` write the path twice: once from the base-order loop,
again from the added loop. The result is a fixture tar with a duplicated member
that no op reports as an error. Pre-existing and not reachable today — the sole
`RemoveFile` call site never re-adds — but `PutFile`'s "whether or not it already
exists" contract is what makes the pairing something an author would reach for, so
it is fixed here rather than documented as a footgun.

Same commit pins three `PutFile` edges: a non-regular target fails with
`ErrNotRegular` (a real risk for these paths, not a theoretical one — the base
ships `etc/ssl/cert.pem` and `etc/ssl/certs/ca-bundle.crt` as symlinks to
`ca-certificates.crt`); idempotency covers the create branch; and `safePath` is
checked in `PutFile` itself, making a guarantee that was emergent from two other
functions local. `doc.go`'s op list had drifted to four of seven ops.

`25c9bfb` — **base composition is now asserted directly.** Converting all 29 calls
to `PutFile` removes the base-drift alarm from the whole matrix at once: the
`ErrExists` that fired when the base gained `openssl.cnf` was crude, but it was
the only thing that noticed, and afterwards the failure mode inverts from "CI
breaks confusingly" to "a fixture quietly asserts less than its name claims".

`TestBaseImageComposition` covers that surface where the cause is, rather than as
a downstream verdict flip: paths an existence-precondition op needs; paths whose
**absence** gives a fixture its discriminating power (the FIPS ssh drop-ins,
`fipsmodule.cnf`, the Java truststore pair behind `CertificateAudit` tst:5's
`none_exist`); `PutFile` targets being absent or regular files; and no FIPS apk
packages installed. Each row carries why it matters, so a failure explains itself.

`etc/ssl/openssl.cnf` is asserted only as "absent or regular" — it is the path
that actually drifted, so pinning it either way would re-create the bet `PutFile`
removed. Re-pinned to #173's digest the check stays green; planting a wrong row in
any of the three path lists turns the matching subtest red naming the path, its
tar type and the dependent fixture. It needs only a registry pull, so it runs in
more environments than the matrix it protects.

This also gives the `fail_clean_no_fips` premise above a real home: both halves of
that control — no `fipsmodule.cnf`, no FIPS packages — are now checked explicitly
rather than resting on a comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
